### PR TITLE
Import flow polish: bug fixes, perf, error visibility, CI

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"1c4b8adc-490f-4780-8655-13c964ec0fa3","pid":76338,"procStart":"Sat May  9 01:17:38 2026","acquiredAt":1778296506898}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"1c4b8adc-490f-4780-8655-13c964ec0fa3","pid":76338,"procStart":"Sat May  9 01:17:38 2026","acquiredAt":1778296506898}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,8 +50,10 @@ jobs:
         run: |
           uv venv
           # Install from pyproject.toml so CI tracks declared deps (incl. google-genai etc.)
-          # setuptools needed for pkg_resources used by some transitive deps.
-          uv pip install . pytest pytest-django gunicorn setuptools
+          # setuptools needed for pkg_resources used by some transitive deps
+          # (e.g. django-simple-history). Pin <81 because setuptools 81+ removed
+          # the vendored `pkg_resources` module.
+          uv pip install . pytest pytest-django gunicorn 'setuptools<81'
       - name: Run tests
         run: |
           source .venv/bin/activate
@@ -97,7 +99,8 @@ jobs:
           # Install from pyproject.toml so CI tracks declared deps automatically.
           # `setuptools` is needed by some transitive deps that still import
           # `pkg_resources` at runtime (uv's venv doesn't include it by default).
-          uv pip install . gunicorn setuptools
+          # Pin <81 because setuptools 81+ removed the vendored `pkg_resources`.
+          uv pip install . gunicorn 'setuptools<81'
       - name: Migrate + seed
         run: |
           source .venv/bin/activate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,9 +55,7 @@ jobs:
       - name: Run tests
         run: |
           source .venv/bin/activate
-          # Use the project's existing test_settings.py (SQLite in-memory)
-          # rather than the CI postgres for now, since that's what local pytest uses
-          pytest billing/ -x --tb=short || true
+          pytest billing/ -x --tb=short
 
   frontend:
     name: Frontend (vitest + Playwright E2E)
@@ -121,23 +119,30 @@ jobs:
           gunicorn gst_billing.wsgi:application --bind 0.0.0.0:8000 --workers 2 --daemon
           sleep 3
           curl -s -o /dev/null -w "Django: %{http_code}\n" http://localhost:8000/api/profile/ || true
-      - name: Build frontend
+      - name: Install frontend deps
         working-directory: sweet-rebuild-suite-main
-        run: |
-          npm ci
-          npm run build
+        run: npm ci
       - name: Run frontend unit tests
         working-directory: sweet-rebuild-suite-main
-        run: npm run test -- --run || true
-      - name: Serve built frontend
+        run: npm run test -- --run
+      - name: Start Vite dev server (with /api proxy to Django)
         working-directory: sweet-rebuild-suite-main
         run: |
-          npx serve -s dist -l 8080 &
-          sleep 2
-          curl -s -o /dev/null -w "Frontend: %{http_code}\n" http://localhost:8080/ || true
+          # Vite dev server proxies /api → http://127.0.0.1:8000 (see vite.config.ts).
+          # Production build + `npx serve` would NOT proxy, so login/API calls would
+          # land back on the frontend host.
+          nohup npx vite --port 8080 --host 0.0.0.0 > /tmp/vite.log 2>&1 &
+          for i in $(seq 1 30); do
+            if curl -fs http://localhost:8080/ >/dev/null 2>&1; then
+              echo "Vite ready"; break
+            fi
+            sleep 1
+          done
+          curl -s -o /dev/null -w "Frontend: %{http_code}\n" http://localhost:8080/
+          curl -s -o /dev/null -w "API via proxy: %{http_code}\n" http://localhost:8080/api/profile/
       - name: Install Playwright
         run: |
-          cd e2e-tests || mkdir -p e2e-tests && cd e2e-tests
+          cd e2e-tests
           npm init -y >/dev/null 2>&1
           npm install -D @playwright/test
           npx playwright install --with-deps chromium
@@ -145,10 +150,7 @@ jobs:
         working-directory: e2e-tests
         env:
           BASE_URL: http://localhost:8080
-        run: |
-          # Override baseURL in playwright.config.js to point at localhost:8080
-          # The tests are already in e2e-tests/tests/
-          npx playwright test --reporter=list || true
+        run: npx playwright test --reporter=list
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,158 @@
+name: Tests
+
+# Runs the backend unit tests + Playwright E2E tests on every push and PR.
+# Uses an in-runner Postgres + Django + Vite stack so no external DB credentials
+# leak into CI.
+
+on:
+  push:
+    branches:
+      - main
+      - polish
+      - new_ui
+  pull_request:
+    branches: [main]
+
+jobs:
+  backend:
+    name: Backend (pytest)
+    runs-on: ubuntu-24.04
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: gst_test
+          POSTGRES_PASSWORD: gst_test_local
+          POSTGRES_DB: gst_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U gst_test"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    env:
+      DJANGO_SETTINGS_MODULE: gst_billing.test_settings
+      DB_HOST: localhost
+      DB_PORT: 5432
+      DB_NAME: gst_test
+      DB_USER: gst_test
+      DB_PASSWORD: gst_test_local
+      DJANGO_SECRET_KEY: ci-test-key-not-secret
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install uv
+        run: pip install uv
+      - name: Install dependencies
+        run: |
+          uv venv
+          uv pip install -r requirements.txt 2>/dev/null || \
+            uv pip install Django djangorestframework djangorestframework-simplejwt django-cors-headers \
+              django-crispy-forms django-htmx django-sql-explorer django-simple-history django-cacheops \
+              psycopg2-binary openpyxl xlsx-js-style num2words pytest pytest-django python-dotenv
+      - name: Run tests
+        run: |
+          source .venv/bin/activate
+          # Use the project's existing test_settings.py (SQLite in-memory)
+          # rather than the CI postgres for now, since that's what local pytest uses
+          pytest billing/ -x --tb=short || true
+
+  frontend:
+    name: Frontend (vitest + Playwright E2E)
+    runs-on: ubuntu-24.04
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: gst_test
+          POSTGRES_PASSWORD: gst_test_local
+          POSTGRES_DB: gst_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U gst_test"
+          --health-interval 5s
+    env:
+      DJANGO_SETTINGS_MODULE: gst_billing.production_settings
+      DB_HOST: localhost
+      DB_PORT: 5432
+      DB_NAME: gst_test
+      DB_USER: gst_test
+      DB_PASSWORD: gst_test_local
+      DJANGO_SECRET_KEY: ci-test-key-not-secret
+      DEBUG: "False"
+      DJANGO_ALLOWED_HOSTS: "*"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install backend deps
+        run: |
+          pip install uv
+          uv venv
+          uv pip install Django djangorestframework djangorestframework-simplejwt django-cors-headers \
+            django-crispy-forms django-htmx django-sql-explorer django-simple-history django-cacheops \
+            psycopg2-binary openpyxl xlsx-js-style num2words gunicorn python-dotenv
+      - name: Migrate + seed
+        run: |
+          source .venv/bin/activate
+          mkdir -p logs
+          python manage.py migrate --noinput
+          python manage.py shell -c "
+          from django.contrib.auth.models import User
+          from billing.models import Business, Customer, Product
+          u, _ = User.objects.get_or_create(username='testuser', defaults={'is_superuser': True, 'is_staff': True})
+          u.set_password('testpass2026'); u.save()
+          b, _ = Business.objects.get_or_create(name='TEST JEWELLERS', defaults={'gst_number':'08TEST1234A1ZA','address':'Test','state_name':'RAJASTHAN','pan_number':'TEST1234A','mobile_number':'9999999999'})
+          c, _ = Customer.objects.get_or_create(name='TEST CUSTOMER', defaults={'state_name':'RAJASTHAN','mobile_number':'8888888888'})
+          c.businesses.add(b)
+          Product.objects.get_or_create(name='Gold Ornaments', defaults={'hsn_code':'711319','gst_tax_rate':0.03})
+          "
+      - name: Start backend
+        run: |
+          source .venv/bin/activate
+          gunicorn gst_billing.wsgi:application --bind 0.0.0.0:8000 --workers 2 --daemon
+          sleep 3
+          curl -s -o /dev/null -w "Django: %{http_code}\n" http://localhost:8000/api/profile/ || true
+      - name: Build frontend
+        working-directory: sweet-rebuild-suite-main
+        run: |
+          npm ci
+          npm run build
+      - name: Run frontend unit tests
+        working-directory: sweet-rebuild-suite-main
+        run: npm run test -- --run || true
+      - name: Serve built frontend
+        working-directory: sweet-rebuild-suite-main
+        run: |
+          npx serve -s dist -l 8080 &
+          sleep 2
+          curl -s -o /dev/null -w "Frontend: %{http_code}\n" http://localhost:8080/ || true
+      - name: Install Playwright
+        run: |
+          cd e2e-tests || mkdir -p e2e-tests && cd e2e-tests
+          npm init -y >/dev/null 2>&1
+          npm install -D @playwright/test
+          npx playwright install --with-deps chromium
+      - name: Run E2E tests
+        working-directory: e2e-tests
+        env:
+          BASE_URL: http://localhost:8080
+        run: |
+          # Override baseURL in playwright.config.js to point at localhost:8080
+          # The tests are already in e2e-tests/tests/
+          npx playwright test --reporter=list || true
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: e2e-tests/playwright-report/
+          retention-days: 7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,27 +17,11 @@ jobs:
   backend:
     name: Backend (pytest)
     runs-on: ubuntu-24.04
-    services:
-      postgres:
-        image: postgres:16-alpine
-        env:
-          POSTGRES_USER: gst_test
-          POSTGRES_PASSWORD: gst_test_local
-          POSTGRES_DB: gst_test
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U gst_test"
-          --health-interval 5s
-          --health-timeout 3s
-          --health-retries 10
+    # No Postgres service — gst_billing.test_settings forces SQLite (:memory:)
+    # for fast unit tests. The DB_* env vars and Postgres provisioning would be
+    # ignored. The frontend job below still uses Postgres for E2E migrate/seed.
     env:
       DJANGO_SETTINGS_MODULE: gst_billing.test_settings
-      DB_HOST: localhost
-      DB_PORT: 5432
-      DB_NAME: gst_test
-      DB_USER: gst_test
-      DB_PASSWORD: gst_test_local
       DJANGO_SECRET_KEY: ci-test-key-not-secret
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,8 @@ jobs:
         run: |
           uv venv
           # Install from pyproject.toml so CI tracks declared deps (incl. google-genai etc.)
-          uv pip install . pytest pytest-django gunicorn
+          # setuptools needed for pkg_resources used by some transitive deps.
+          uv pip install . pytest pytest-django gunicorn setuptools
       - name: Run tests
         run: |
           source .venv/bin/activate
@@ -95,8 +96,10 @@ jobs:
         run: |
           pip install uv
           uv venv
-          # Install from pyproject.toml so CI tracks declared deps automatically
-          uv pip install . gunicorn
+          # Install from pyproject.toml so CI tracks declared deps automatically.
+          # `setuptools` is needed by some transitive deps that still import
+          # `pkg_resources` at runtime (uv's venv doesn't include it by default).
+          uv pip install . gunicorn setuptools
       - name: Migrate + seed
         run: |
           source .venv/bin/activate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
           uv pip install -r requirements.txt 2>/dev/null || \
             uv pip install Django djangorestframework djangorestframework-simplejwt django-cors-headers \
               django-crispy-forms django-htmx django-sql-explorer django-simple-history django-cacheops \
-              psycopg2-binary openpyxl xlsx-js-style num2words pytest pytest-django python-dotenv
+              psycopg2-binary openpyxl num2words pytest pytest-django python-dotenv
       - name: Run tests
         run: |
           source .venv/bin/activate
@@ -99,7 +99,7 @@ jobs:
           uv venv
           uv pip install Django djangorestframework djangorestframework-simplejwt django-cors-headers \
             django-crispy-forms django-htmx django-sql-explorer django-simple-history django-cacheops \
-            psycopg2-binary openpyxl xlsx-js-style num2words gunicorn python-dotenv
+            psycopg2-binary openpyxl num2words gunicorn python-dotenv
       - name: Migrate + seed
         run: |
           source .venv/bin/activate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,10 +128,12 @@ jobs:
           curl -s -o /dev/null -w "Frontend: %{http_code}\n" http://localhost:8080/
           curl -s -o /dev/null -w "API via proxy: %{http_code}\n" http://localhost:8080/api/profile/
       - name: Install Playwright
+        working-directory: e2e-tests
         run: |
-          cd e2e-tests
-          npm init -y >/dev/null 2>&1
-          npm install -D @playwright/test
+          # e2e-tests/package.json + lockfile are checked in, so npm ci
+          # is reproducible and cache-friendly (vs the previous
+          # `npm init -y && npm install` which had no lockfile).
+          npm ci
           npx playwright install --with-deps chromium
       - name: Run E2E tests
         working-directory: e2e-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,10 +49,8 @@ jobs:
       - name: Install dependencies
         run: |
           uv venv
-          uv pip install -r requirements.txt 2>/dev/null || \
-            uv pip install Django djangorestframework djangorestframework-simplejwt django-cors-headers \
-              django-crispy-forms django-htmx django-sql-explorer django-simple-history django-cacheops \
-              psycopg2-binary openpyxl num2words pytest pytest-django python-dotenv
+          # Install from pyproject.toml so CI tracks declared deps (incl. google-genai etc.)
+          uv pip install . pytest pytest-django gunicorn
       - name: Run tests
         run: |
           source .venv/bin/activate
@@ -97,9 +95,8 @@ jobs:
         run: |
           pip install uv
           uv venv
-          uv pip install Django djangorestframework djangorestframework-simplejwt django-cors-headers \
-            django-crispy-forms django-htmx django-sql-explorer django-simple-history django-cacheops \
-            psycopg2-binary openpyxl num2words gunicorn python-dotenv
+          # Install from pyproject.toml so CI tracks declared deps automatically
+          uv pip install . gunicorn
       - name: Migrate + seed
         run: |
           source .venv/bin/activate

--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,16 @@ node_modules/*
 
 .DS_Store
 dump.json
+
+# DB backups containing real data
+backups/
+
+# Playwright/E2E test artifacts
+e2e-results/
+e2e-tests/node_modules/
+e2e-tests/test-results/
+e2e-tests/playwright-report/
+e2e-tests/auth-state.json
+
+# Stray nested duplicate of the React app
+sweet-rebuild-suite-main/sweet-rebuild-suite-main/

--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,7 @@ e2e-tests/node_modules/
 e2e-tests/test-results/
 e2e-tests/playwright-report/
 e2e-tests/auth-state.json
+audit-results/
 
 # Claude Code runtime artifacts
 .claude/scheduled_tasks.lock

--- a/.gitignore
+++ b/.gitignore
@@ -155,5 +155,8 @@ e2e-tests/test-results/
 e2e-tests/playwright-report/
 e2e-tests/auth-state.json
 
+# Claude Code runtime artifacts
+.claude/scheduled_tasks.lock
+
 # Stray nested duplicate of the React app
 sweet-rebuild-suite-main/sweet-rebuild-suite-main/

--- a/billing/api/mixins.py
+++ b/billing/api/mixins.py
@@ -17,11 +17,23 @@ class AuditLogMixin:
     def get_entity_name(self, instance) -> str:
         return str(instance)
 
+    def _field_value(self, instance, field):
+        """
+        Return the snapshot value for one model field.
+
+        For FK fields, return the FK column value (the ID), not the related
+        instance's __str__ — otherwise undo can't restore the relation. e.g.
+        for `business`, we want `business_id`'s integer, not "LODHA JEWELLERS".
+        """
+        if field.is_relation and field.many_to_one:
+            return getattr(instance, field.attname, None)  # e.g. business_id
+        return getattr(instance, field.name, None)
+
     def _snapshot(self, instance) -> dict:
         data = {}
         for field in instance._meta.concrete_fields:
             if field.name not in EXCLUDED_FIELDS:
-                value = getattr(instance, field.name)
+                value = self._field_value(instance, field)
                 data[field.name] = str(value) if value is not None else None
         return data
 
@@ -29,11 +41,8 @@ class AuditLogMixin:
         """Full snapshot including all fields for undo."""
         data = {}
         for field in instance._meta.concrete_fields:
-            value = getattr(instance, field.name)
-            if value is not None:
-                data[field.name] = str(value)
-            else:
-                data[field.name] = None
+            value = self._field_value(instance, field)
+            data[field.name] = str(value) if value is not None else None
         return data
 
     def _compute_changes(self, old_snapshot: dict, new_snapshot: dict) -> dict:
@@ -67,18 +76,22 @@ class AuditLogMixin:
                   snapshot=self._full_snapshot(instance))
 
     def perform_update(self, serializer):
-        instance = self.get_object()
+        # serializer.instance is already loaded by the viewset (one DB hit).
+        # Snapshot it BEFORE save (still has old values), then save, then snapshot
+        # again (serializer.save() updates instance in-place).
+        # Saves: 1 redundant get_object() + 1 refresh_from_db() vs the old impl.
+        instance = serializer.instance
         old_snapshot = self._snapshot(instance)
         full_old = self._full_snapshot(instance)
         super().perform_update(serializer)
-        instance.refresh_from_db()
-        new_snapshot = self._snapshot(instance)
+        # serializer.instance is mutated in place by save() — read fresh values directly
+        new_snapshot = self._snapshot(serializer.instance)
         changes = self._compute_changes(old_snapshot, new_snapshot)
         if changes:
             changed_fields = ", ".join(changes.keys())
             details = f"Updated {changed_fields}"
             self._log(
-                "updated", instance, self.request.user,
+                "updated", serializer.instance, self.request.user,
                 changes=changes, details=details, snapshot=full_old,
             )
 

--- a/billing/api/serializers.py
+++ b/billing/api/serializers.py
@@ -51,6 +51,9 @@ class CustomerSerializer(serializers.ModelSerializer):
     class Meta:
         model = Customer
         fields = "__all__"
+        # M2M to Business is optional on create — many customers are added
+        # without immediately linking to a business
+        extra_kwargs = {"businesses": {"required": False}}
 
 
 class ProductSerializer(serializers.ModelSerializer):

--- a/billing/api/views.py
+++ b/billing/api/views.py
@@ -2346,19 +2346,30 @@ class BulkInvoiceImportView(APIView):
                     for item in items:
                         qty = Decimal(str(item.get("qty", 0)))
                         rate = Decimal(str(item.get("rate", 0)))
-                        gst_rate = Decimal(str(item.get("gstRate", 3))) / Decimal("100")
-                        net_amount = qty * rate
-                        tax_amount = net_amount * gst_rate
+                        gst_rate_raw = Decimal(str(item.get("gstRate", 3)))
+                        # Accept either decimal (0.03) or percentage (3)
+                        gst_rate = gst_rate_raw if gst_rate_raw <= 1 else gst_rate_raw / Decimal("100")
                         cgst = Decimal(str(item.get("cgst", 0)))
                         sgst = Decimal(str(item.get("sgst", 0)))
                         igst = Decimal(str(item.get("igst", 0)))
+                        # User-supplied gross amount takes precedence — they may not have qty/rate
+                        user_amount = Decimal(str(item.get("amount", 0)))
+                        net_amount = qty * rate
+                        if net_amount == 0 and user_amount > 0:
+                            # Back-derive net from gross + taxes
+                            net_amount = user_amount - cgst - sgst - igst
+                            if net_amount < 0:
+                                # Edge case: caller sent amount but no taxes — treat as gross-incl-tax
+                                net_amount = user_amount / (1 + gst_rate)
+                        tax_amount = net_amount * gst_rate
                         if cgst == 0 and sgst == 0 and igst == 0:
                             if is_igst:
                                 igst = tax_amount
                             else:
                                 cgst = tax_amount / 2
                                 sgst = tax_amount / 2
-                        amount = net_amount + cgst + sgst + igst
+                        # Final amount: prefer user-supplied if non-zero, else net + taxes
+                        amount = user_amount if user_amount > 0 else (net_amount + cgst + sgst + igst)
                         line_items_to_create.append(LineItem(
                             invoice=invoice, customer=invoice.customer,
                             product_name=item.get("productName", "Item"),

--- a/billing/api/views.py
+++ b/billing/api/views.py
@@ -2218,7 +2218,8 @@ class BulkInvoiceImportView(APIView):
             inv_no = str(inv_data.get("invoiceNumber", "") or "")
             inv_date = inv_data.get("invoice_date", "") or ""
             wanted_inv_keys.add((inv_no, inv_date))
-        # We don't know business yet for each, so just fetch by invoice_number+date
+        # Dedup key includes type_of_invoice — sales bill #1 and purchase bill #1
+        # are different documents, even with the same number/date/firm.
         existing_invoice_keys = set()
         if wanted_inv_keys:
             inv_no_list = list({k[0] for k in wanted_inv_keys})
@@ -2226,9 +2227,10 @@ class BulkInvoiceImportView(APIView):
             for inv in Invoice.objects.filter(
                 invoice_number__in=inv_no_list,
                 invoice_date__in=inv_date_list,
-            ).only("id", "invoice_number", "invoice_date", "business_id"):
+            ).only("id", "invoice_number", "invoice_date", "business_id", "type_of_invoice"):
                 existing_invoice_keys.add(
-                    (inv.business_id, str(inv.invoice_number), str(inv.invoice_date))
+                    (inv.business_id, str(inv.invoice_number), str(inv.invoice_date),
+                     (inv.type_of_invoice or INVOICE_TYPE_OUTWARD).lower())
                 )
 
         # ---------- PHASE 2: process invoices in a single transaction ----------
@@ -2301,19 +2303,21 @@ class BulkInvoiceImportView(APIView):
                         # Track for M2M attach (idempotent — .add() is a no-op if exists)
                         new_customers_added_to_biz.append((customer, business))
 
-                    # Duplicate check from the prefetched set
+                    # Resolve invoice type first so duplicate key includes it.
                     invoice_number = str(inv_data.get("invoiceNumber", ""))
                     invoice_date = inv_data.get("invoice_date", "")
-                    if (business.pk, invoice_number, str(invoice_date)) in existing_invoice_keys:
-                        skipped_count += 1
-                        continue
-
                     inv_type = inv_data.get("type", "OUTWARD")
                     type_of_invoice = (
                         INVOICE_TYPE_INWARD
                         if inv_type == "INWARD"
                         else INVOICE_TYPE_OUTWARD
                     )
+
+                    # Duplicate check — must match on business + bill# + date AND type
+                    dup_key = (business.pk, invoice_number, str(invoice_date), type_of_invoice.lower())
+                    if dup_key in existing_invoice_keys:
+                        skipped_count += 1
+                        continue
 
                     # Build invoice in memory; bulk_create later
                     invoice = Invoice(
@@ -2327,9 +2331,7 @@ class BulkInvoiceImportView(APIView):
                     )
                     invoices_to_create.append((invoice, inv_data))
                     # Mark as seen so a duplicate row in the same payload is skipped
-                    existing_invoice_keys.add(
-                        (business.pk, invoice_number, str(invoice_date))
-                    )
+                    existing_invoice_keys.add(dup_key)
                     created_count += 1
 
                 except Exception as e:

--- a/billing/api/views.py
+++ b/billing/api/views.py
@@ -2396,6 +2396,28 @@ class BulkInvoiceImportView(APIView):
                                 cgst = tax_amount / 2
                                 sgst = tax_amount / 2
                         amount = user_amount if user_amount > 0 else (net_amount + cgst + sgst + igst)
+
+                        # Validate per-field DB constraints BEFORE bulk_create so
+                        # a single bad row doesn't 500 the whole batch.
+                        # quantity / cgst / sgst / igst are NUMERIC(10,3) → abs < 10^7
+                        # rate / amount / gst_tax_rate are NUMERIC(12,3) → abs < 10^9
+                        OVERFLOW_10 = Decimal("10000000")
+                        OVERFLOW_12 = Decimal("1000000000")
+                        bad = None
+                        if abs(qty) >= OVERFLOW_10: bad = ("quantity", qty)
+                        elif abs(cgst) >= OVERFLOW_10: bad = ("cgst", cgst)
+                        elif abs(sgst) >= OVERFLOW_10: bad = ("sgst", sgst)
+                        elif abs(igst) >= OVERFLOW_10: bad = ("igst", igst)
+                        elif abs(rate) >= OVERFLOW_12: bad = ("rate", rate)
+                        elif abs(amount) >= OVERFLOW_12: bad = ("amount", amount)
+                        if bad:
+                            errors.append(
+                                f"Invoice {inv_data.get('invoiceNumber','?')} item '{product_name}': "
+                                f"{bad[0]} value {bad[1]} exceeds DB limit. "
+                                f"Likely qty×rate computation error — check input."
+                            )
+                            continue
+
                         line_items_to_create.append(LineItem(
                             invoice=invoice, customer=invoice.customer,
                             product_name=product_name or "Item",

--- a/billing/api/views.py
+++ b/billing/api/views.py
@@ -2309,7 +2309,14 @@ class BulkInvoiceImportView(APIView):
                             pan_number=clean_pan, state_name="RAJASTHAN",
                             workspace_id=1,
                         )
+                        # Update ALL lookup caches so a later row referencing the
+                        # same GST/PAN under a different name resolves to this
+                        # customer instead of creating a duplicate.
                         cust_by_name[customer_name.lower()] = customer
+                        if clean_gst:
+                            cust_by_gst[clean_gst.upper()] = customer
+                        if clean_pan:
+                            cust_by_pan[clean_pan.upper()] = customer
 
                     if business and business.pk and customer.pk:
                         # Track for M2M attach (idempotent — .add() is a no-op if exists)
@@ -2389,12 +2396,15 @@ class BulkInvoiceImportView(APIView):
                     items = inv_data.get("items", [])
                     is_igst = invoice.is_igst_applicable
                     for item in items:
-                        product_name = (item.get("productName") or "").strip()
+                        # Excel cells can come through as numbers (e.g. HSN "711319"
+                        # parsed as int) — coerce to str before .strip() so one
+                        # numeric cell can't AttributeError the whole batch.
+                        product_name = str(item.get("productName") or "").strip()
                         # Resolve HSN + GST rate from Product master if not supplied.
                         # Never silently default — if the row has no GST rate AND
                         # no matching product, fail with a clear message.
                         product = lookup_product(product_name)
-                        hsn_code = (item.get("hsn") or "").strip()
+                        hsn_code = str(item.get("hsn") or "").strip()
                         gst_rate_raw_in = item.get("gstRate")
                         if gst_rate_raw_in in (None, "", 0, "0"):
                             if not product:

--- a/billing/api/views.py
+++ b/billing/api/views.py
@@ -2159,6 +2159,14 @@ class BulkInvoiceImportView(APIView):
             if c.name:
                 cust_by_name[c.name.lower()] = c
 
+        # Product master lookup — by lowercase name. Used to resolve HSN +
+        # GST rate when the import file doesn't supply them, so we never
+        # silently default to magic numbers.
+        product_by_name = {}
+        for p in Product.objects.all().only("id", "name", "hsn_code", "gst_tax_rate"):
+            if p.name:
+                product_by_name[p.name.lower()] = p
+
         # ---------- PRE-PASS: bulk-create new customers in ONE round-trip ----------
         # Walk all invoices, identify customer names that don't exist yet, dedupe,
         # bulk_create. Avoids N serial INSERTs when many invoices reference new
@@ -2344,11 +2352,32 @@ class BulkInvoiceImportView(APIView):
                     items = inv_data.get("items", [])
                     is_igst = invoice.is_igst_applicable
                     for item in items:
+                        product_name = (item.get("productName") or "").strip()
+                        # Resolve HSN + GST rate from Product master if not supplied.
+                        # Never silently default — if the row has no GST rate AND
+                        # no matching product, fail with a clear message.
+                        product = product_by_name.get(product_name.lower())
+                        hsn_code = (item.get("hsn") or "").strip()
+                        gst_rate_raw_in = item.get("gstRate")
+                        if gst_rate_raw_in in (None, "", 0, "0"):
+                            if not product:
+                                errors.append(
+                                    f"Invoice {inv_data.get('invoiceNumber','?')} item '{product_name}': "
+                                    f"product not found in Product list and no GST rate supplied. "
+                                    f"Add the product first or include a GST Rate column."
+                                )
+                                continue
+                            gst_rate = Decimal(str(product.gst_tax_rate))
+                            if not hsn_code:
+                                hsn_code = product.hsn_code or ""
+                        else:
+                            gst_rate_raw = Decimal(str(gst_rate_raw_in))
+                            gst_rate = gst_rate_raw if gst_rate_raw <= 1 else gst_rate_raw / Decimal("100")
+                            if not hsn_code and product:
+                                hsn_code = product.hsn_code or ""
+
                         qty = Decimal(str(item.get("qty", 0)))
                         rate = Decimal(str(item.get("rate", 0)))
-                        gst_rate_raw = Decimal(str(item.get("gstRate", 3)))
-                        # Accept either decimal (0.03) or percentage (3)
-                        gst_rate = gst_rate_raw if gst_rate_raw <= 1 else gst_rate_raw / Decimal("100")
                         cgst = Decimal(str(item.get("cgst", 0)))
                         sgst = Decimal(str(item.get("sgst", 0)))
                         igst = Decimal(str(item.get("igst", 0)))
@@ -2356,10 +2385,8 @@ class BulkInvoiceImportView(APIView):
                         user_amount = Decimal(str(item.get("amount", 0)))
                         net_amount = qty * rate
                         if net_amount == 0 and user_amount > 0:
-                            # Back-derive net from gross + taxes
                             net_amount = user_amount - cgst - sgst - igst
                             if net_amount < 0:
-                                # Edge case: caller sent amount but no taxes — treat as gross-incl-tax
                                 net_amount = user_amount / (1 + gst_rate)
                         tax_amount = net_amount * gst_rate
                         if cgst == 0 and sgst == 0 and igst == 0:
@@ -2368,12 +2395,11 @@ class BulkInvoiceImportView(APIView):
                             else:
                                 cgst = tax_amount / 2
                                 sgst = tax_amount / 2
-                        # Final amount: prefer user-supplied if non-zero, else net + taxes
                         amount = user_amount if user_amount > 0 else (net_amount + cgst + sgst + igst)
                         line_items_to_create.append(LineItem(
                             invoice=invoice, customer=invoice.customer,
-                            product_name=item.get("productName", "Item"),
-                            hsn_code=item.get("hsn", "711319"),
+                            product_name=product_name or "Item",
+                            hsn_code=hsn_code or "",
                             gst_tax_rate=gst_rate,
                             quantity=qty, rate=rate,
                             cgst=cgst, sgst=sgst, igst=igst, amount=amount,
@@ -2390,22 +2416,43 @@ class BulkInvoiceImportView(APIView):
             if line_items_to_create:
                 LineItem.objects.bulk_create(line_items_to_create, batch_size=200)
 
-            # Safety net: recompute Invoice.total_amount from line items.
-            # bulk_create doesn't fire the post_save signal that normally keeps
-            # totals in sync. We trust the front-end-supplied total in inv_data
-            # but also re-sync to be defensive in case the payload was wrong.
+            # If any invoices ended up with NO line items (all their items errored
+            # out during product/GST resolution), they must be removed — otherwise
+            # they'd be created with NULL total_amount, which violates the column
+            # constraint and corrupts the database with stub invoices.
             if invoices_to_create:
-                from django.db.models import OuterRef, Subquery, Sum, DecimalField
+                from django.db.models import OuterRef, Subquery, Sum, DecimalField, Q
+                from django.db.models.functions import Coalesce
                 invoice_ids = [inv.pk for inv, _ in invoices_to_create if inv.pk]
                 if invoice_ids:
-                    sub = (LineItem.objects
-                           .filter(invoice=OuterRef("pk"))
-                           .values("invoice")
-                           .annotate(s=Sum("amount"))
-                           .values("s"))
-                    Invoice.objects.filter(pk__in=invoice_ids).update(
-                        total_amount=Subquery(sub, output_field=DecimalField())
+                    # Find invoices with no line items and decrement counters
+                    empty_inv_ids = list(
+                        Invoice.objects.filter(pk__in=invoice_ids, lineitem__isnull=True)
+                        .values_list("pk", flat=True)
                     )
+                    if empty_inv_ids:
+                        # Roll back stub invoices and adjust counters
+                        Invoice.objects.filter(pk__in=empty_inv_ids).delete()
+                        invoice_ids = [pk for pk in invoice_ids if pk not in empty_inv_ids]
+                        created_count -= len(empty_inv_ids)
+                        skipped_count += len(empty_inv_ids)
+
+                    # Safety net: recompute Invoice.total_amount = SUM(line_items)
+                    # for the surviving invoices. bulk_create skips the post_save
+                    # signal that normally keeps total in sync, so we re-derive.
+                    if invoice_ids:
+                        sub = (LineItem.objects
+                               .filter(invoice=OuterRef("pk"))
+                               .values("invoice")
+                               .annotate(s=Sum("amount"))
+                               .values("s"))
+                        Invoice.objects.filter(pk__in=invoice_ids).update(
+                            total_amount=Coalesce(
+                                Subquery(sub, output_field=DecimalField()),
+                                Decimal("0"),
+                                output_field=DecimalField(),
+                            )
+                        )
 
             # Add per-row error entries to the audit log so failures are
             # visible in the UI's audit log page (not just Django logs).

--- a/billing/api/views.py
+++ b/billing/api/views.py
@@ -2249,6 +2249,10 @@ class BulkInvoiceImportView(APIView):
         invoices_to_create = []  # [(Invoice instance, source dict for line items)]
         line_items_to_create = []
         audit_logs_to_create = []
+        # Per-invoice audit metadata (pk, display name, item count). Audit logs
+        # are emitted after total_amount is recomputed from line items so the
+        # message reflects the persisted total, not the stale in-memory value.
+        pending_invoice_audits: list[dict] = []
         new_customers_added_to_biz = []  # (customer, business) pairs
 
         with transaction.atomic():
@@ -2474,13 +2478,14 @@ class BulkInvoiceImportView(APIView):
                             cgst=cgst, sgst=sgst, igst=igst, amount=amount,
                             workspace_id=1,
                         ))
-                    audit_logs_to_create.append(AuditLog(
-                        action="imported", entity="invoice",
-                        entity_id=invoice.pk,
-                        entity_name=f"#{invoice.invoice_number} - {invoice.customer.name}",
-                        user=request.user if request.user and request.user.is_authenticated else None,
-                        details=f"Imported from Excel ({len(items)} items, total: {invoice.total_amount})",
-                    ))
+                    # Stash the metadata we need for the audit log; the actual
+                    # AuditLog row is appended below after total_amount has been
+                    # recomputed from line items, so the logged total isn't stale.
+                    pending_invoice_audits.append({
+                        "pk": invoice.pk,
+                        "name": f"#{invoice.invoice_number} - {invoice.customer.name}",
+                        "item_count": len(items),
+                    })
 
             if line_items_to_create:
                 LineItem.objects.bulk_create(line_items_to_create, batch_size=200)
@@ -2524,6 +2529,29 @@ class BulkInvoiceImportView(APIView):
                             )
                         )
 
+            # Emit the deferred per-invoice audit logs now that total_amount
+            # has been recomputed from line items (and dropped invoices that
+            # were rolled back as empty).
+            if pending_invoice_audits:
+                empty_set = set(empty_inv_ids)
+                surviving_pks = [a["pk"] for a in pending_invoice_audits if a["pk"] not in empty_set]
+                live_totals = dict(
+                    Invoice.objects.filter(pk__in=surviving_pks).values_list("pk", "total_amount")
+                )
+                for meta in pending_invoice_audits:
+                    if meta["pk"] in empty_set:
+                        continue
+                    audit_logs_to_create.append(AuditLog(
+                        action="imported", entity="invoice",
+                        entity_id=meta["pk"],
+                        entity_name=meta["name"],
+                        user=request.user if request.user and request.user.is_authenticated else None,
+                        details=(
+                            f"Imported from Excel ({meta['item_count']} items, "
+                            f"total: {live_totals.get(meta['pk'], 0)})"
+                        ),
+                    ))
+
             # Add per-row error entries to the audit log so failures are
             # visible in the UI's audit log page (not just Django logs).
             if errors:
@@ -2536,17 +2564,7 @@ class BulkInvoiceImportView(APIView):
                     ))
 
             if audit_logs_to_create:
-                # Drop audit logs that reference invoices we just deleted (those
-                # whose line items all errored out) so we don't leave dangling
-                # entity_id references in the audit log.
-                if empty_inv_ids:
-                    empty_set = set(empty_inv_ids)
-                    audit_logs_to_create = [
-                        log for log in audit_logs_to_create
-                        if not (log.entity == "invoice" and log.entity_id in empty_set)
-                    ]
-                if audit_logs_to_create:
-                    AuditLog.objects.bulk_create(audit_logs_to_create, batch_size=200)
+                AuditLog.objects.bulk_create(audit_logs_to_create, batch_size=200)
 
             # Link new customers to businesses via M2M — bulk_create the through-table
             # rows instead of N individual .add() calls (each is its own round-trip).

--- a/billing/api/views.py
+++ b/billing/api/views.py
@@ -2486,11 +2486,12 @@ class BulkInvoiceImportView(APIView):
                 LineItem.objects.bulk_create(line_items_to_create, batch_size=200)
 
             # If any invoices ended up with NO line items (all their items errored
-            # out during product/GST resolution), they must be removed — otherwise
-            # they'd be created with NULL total_amount, which violates the column
-            # constraint and corrupts the database with stub invoices.
+            # out during product/GST resolution), they must be removed — leaving
+            # stub invoices behind would corrupt counters and confuse downstream
+            # reports. (total_amount defaults to 0 so NULL isn't the failure mode.)
+            empty_inv_ids: list[int] = []
             if invoices_to_create:
-                from django.db.models import OuterRef, Subquery, Sum, DecimalField, Q
+                from django.db.models import OuterRef, Subquery, Sum, DecimalField
                 from django.db.models.functions import Coalesce
                 invoice_ids = [inv.pk for inv, _ in invoices_to_create if inv.pk]
                 if invoice_ids:
@@ -2535,7 +2536,17 @@ class BulkInvoiceImportView(APIView):
                     ))
 
             if audit_logs_to_create:
-                AuditLog.objects.bulk_create(audit_logs_to_create, batch_size=200)
+                # Drop audit logs that reference invoices we just deleted (those
+                # whose line items all errored out) so we don't leave dangling
+                # entity_id references in the audit log.
+                if empty_inv_ids:
+                    empty_set = set(empty_inv_ids)
+                    audit_logs_to_create = [
+                        log for log in audit_logs_to_create
+                        if not (log.entity == "invoice" and log.entity_id in empty_set)
+                    ]
+                if audit_logs_to_create:
+                    AuditLog.objects.bulk_create(audit_logs_to_create, batch_size=200)
 
             # Link new customers to businesses via M2M — bulk_create the through-table
             # rows instead of N individual .add() calls (each is its own round-trip).

--- a/billing/api/views.py
+++ b/billing/api/views.py
@@ -2159,13 +2159,25 @@ class BulkInvoiceImportView(APIView):
             if c.name:
                 cust_by_name[c.name.lower()] = c
 
-        # Product master lookup — by lowercase name. Used to resolve HSN +
-        # GST rate when the import file doesn't supply them, so we never
-        # silently default to magic numbers.
-        product_by_name = {}
-        for p in Product.objects.all().only("id", "name", "hsn_code", "gst_tax_rate"):
-            if p.name:
-                product_by_name[p.name.lower()] = p
+        # Product master lookup. Two-tier so case-only duplicates in the
+        # master (e.g. "GOLD COIN" 3% AND "gold coin" 12%) don't silently
+        # apply the wrong tax rate based on DB iteration order.
+        # exact-case wins → falls back to lowercase first-seen.
+        product_by_exact = {}
+        product_by_ci = {}
+        for p in Product.objects.all().only("id", "name", "hsn_code", "gst_tax_rate").order_by("name"):
+            if not p.name:
+                continue
+            if p.name not in product_by_exact:
+                product_by_exact[p.name] = p
+            ci_key = p.name.lower()
+            if ci_key not in product_by_ci:
+                product_by_ci[ci_key] = p
+
+        def lookup_product(name):
+            if not name:
+                return None
+            return product_by_exact.get(name) or product_by_ci.get(name.lower())
 
         # ---------- PRE-PASS: bulk-create new customers in ONE round-trip ----------
         # Walk all invoices, identify customer names that don't exist yet, dedupe,
@@ -2346,9 +2358,32 @@ class BulkInvoiceImportView(APIView):
 
             # ---------- PHASE 3: bulk writes ----------
             # Bulk-create invoices in ONE round-trip. PostgreSQL fills in PKs.
+            # If bulk_create raises for one bad row (e.g. malformed date), we
+            # don't want the whole batch to 500. Try the bulk path first; on
+            # failure, fall back to per-row create so good rows still land
+            # and bad rows surface as per-row errors.
             if invoices_to_create:
                 invoice_objs = [pair[0] for pair in invoices_to_create]
-                Invoice.objects.bulk_create(invoice_objs, batch_size=200)
+                try:
+                    Invoice.objects.bulk_create(invoice_objs, batch_size=200)
+                except Exception as bulk_err:
+                    logger.warning(
+                        "bulk_create failed (%s); falling back to per-row create", bulk_err
+                    )
+                    surviving = []
+                    for invoice, inv_data in invoices_to_create:
+                        try:
+                            invoice.save()
+                            surviving.append((invoice, inv_data))
+                        except Exception as row_err:
+                            errors.append(
+                                f"Invoice {inv_data.get('invoiceNumber','?')}: "
+                                f"could not create — {row_err}"
+                            )
+                            created_count -= 1
+                            skipped_count += 1
+                    invoices_to_create = surviving
+                    invoice_objs = [pair[0] for pair in surviving]
                 # Now invoice.pk is populated; build line items + audit logs.
                 for invoice, inv_data in invoices_to_create:
                     items = inv_data.get("items", [])
@@ -2358,7 +2393,7 @@ class BulkInvoiceImportView(APIView):
                         # Resolve HSN + GST rate from Product master if not supplied.
                         # Never silently default — if the row has no GST rate AND
                         # no matching product, fail with a clear message.
-                        product = product_by_name.get(product_name.lower())
+                        product = lookup_product(product_name)
                         hsn_code = (item.get("hsn") or "").strip()
                         gst_rate_raw_in = item.get("gstRate")
                         if gst_rate_raw_in in (None, "", 0, "0"):

--- a/billing/api/views.py
+++ b/billing/api/views.py
@@ -2159,6 +2159,50 @@ class BulkInvoiceImportView(APIView):
             if c.name:
                 cust_by_name[c.name.lower()] = c
 
+        # ---------- PRE-PASS: bulk-create new customers in ONE round-trip ----------
+        # Walk all invoices, identify customer names that don't exist yet, dedupe,
+        # bulk_create. Avoids N serial INSERTs when many invoices reference new
+        # customers (saves ~700ms on a 10-new-customer import on Neon Singapore).
+        needed_new = {}  # name_lower -> {name, gst, pan}
+        for inv_data in invoices_data:
+            cn = (inv_data.get("customerName") or "").strip()
+            cg = (inv_data.get("customerGST") or "").strip()
+            if not cn:
+                continue
+            key = cn.lower()
+            # Already in cache (pre-existing)? skip
+            if key in cust_by_name:
+                continue
+            clean_gst = ""
+            clean_pan = ""
+            if cg and cg not in ("-", ""):
+                if "(PAN)" in cg:
+                    clean_pan = cg.replace("(PAN)", "").strip()
+                    if clean_pan.upper() in cust_by_pan:
+                        continue
+                else:
+                    clean_gst = cg
+                    if clean_gst.upper() in cust_by_gst:
+                        continue
+            needed_new[key] = {"name": cn, "gst": clean_gst, "pan": clean_pan}
+
+        if needed_new:
+            new_objs = [
+                Customer(
+                    name=info["name"], gst_number=info["gst"],
+                    pan_number=info["pan"], state_name="RAJASTHAN",
+                    workspace_id=1,
+                ) for info in needed_new.values()
+            ]
+            Customer.objects.bulk_create(new_objs, batch_size=200)
+            # Update caches with the freshly-created customers
+            for c in new_objs:
+                cust_by_name[c.name.lower()] = c
+                if c.gst_number:
+                    cust_by_gst[c.gst_number.upper()] = c
+                if c.pan_number:
+                    cust_by_pan[c.pan_number.upper()] = c
+
         # Bulk fetch existing invoices (for duplicate detection) keyed by
         # (business_id, invoice_number, invoice_date)
         wanted_inv_keys = set()
@@ -2180,6 +2224,7 @@ class BulkInvoiceImportView(APIView):
                 )
 
         # ---------- PHASE 2: process invoices in a single transaction ----------
+        invoices_to_create = []  # [(Invoice instance, source dict for line items)]
         line_items_to_create = []
         audit_logs_to_create = []
         new_customers_added_to_biz = []  # (customer, business) pairs
@@ -2235,21 +2280,18 @@ class BulkInvoiceImportView(APIView):
                         customer = cust_by_name.get(customer_name.lower())
 
                     if not customer:
+                        # Should not happen — pre-pass should have bulk-created
+                        # everything. Defensive fallback.
                         customer = Customer.objects.create(
-                            name=customer_name,
-                            gst_number=clean_gst,
-                            pan_number=clean_pan,
-                            state_name="RAJASTHAN",
+                            name=customer_name, gst_number=clean_gst,
+                            pan_number=clean_pan, state_name="RAJASTHAN",
                             workspace_id=1,
                         )
-                        # Cache for downstream rows that reference the same name
                         cust_by_name[customer_name.lower()] = customer
-                        if clean_gst:
-                            cust_by_gst[clean_gst.upper()] = customer
-                        if clean_pan:
-                            cust_by_pan[clean_pan.upper()] = customer
-                        if business and business.pk:
-                            new_customers_added_to_biz.append((customer, business))
+
+                    if business and business.pk and customer.pk:
+                        # Track for M2M attach (idempotent — .add() is a no-op if exists)
+                        new_customers_added_to_biz.append((customer, business))
 
                     # Duplicate check from the prefetched set
                     invoice_number = str(inv_data.get("invoiceNumber", ""))
@@ -2265,7 +2307,8 @@ class BulkInvoiceImportView(APIView):
                         else INVOICE_TYPE_OUTWARD
                     )
 
-                    invoice = Invoice.objects.create(
+                    # Build invoice in memory; bulk_create later
+                    invoice = Invoice(
                         invoice_number=invoice_number,
                         invoice_date=invoice_date,
                         customer=customer,
@@ -2274,57 +2317,11 @@ class BulkInvoiceImportView(APIView):
                         total_amount=Decimal(str(inv_data.get("total", 0))),
                         workspace_id=1,
                     )
+                    invoices_to_create.append((invoice, inv_data))
                     # Mark as seen so a duplicate row in the same payload is skipped
                     existing_invoice_keys.add(
                         (business.pk, invoice_number, str(invoice_date))
                     )
-
-                    items = inv_data.get("items", [])
-                    is_igst = invoice.is_igst_applicable
-                    for item in items:
-                        qty = Decimal(str(item.get("qty", 0)))
-                        rate = Decimal(str(item.get("rate", 0)))
-                        gst_rate = Decimal(str(item.get("gstRate", 3))) / Decimal("100")
-                        net_amount = qty * rate
-                        tax_amount = net_amount * gst_rate
-
-                        cgst = Decimal(str(item.get("cgst", 0)))
-                        sgst = Decimal(str(item.get("sgst", 0)))
-                        igst = Decimal(str(item.get("igst", 0)))
-
-                        if cgst == 0 and sgst == 0 and igst == 0:
-                            if is_igst:
-                                igst = tax_amount
-                            else:
-                                cgst = tax_amount / 2
-                                sgst = tax_amount / 2
-
-                        amount = net_amount + cgst + sgst + igst
-
-                        line_items_to_create.append(LineItem(
-                            invoice=invoice,
-                            customer=customer,
-                            product_name=item.get("productName", "Item"),
-                            hsn_code=item.get("hsn", "711319"),
-                            gst_tax_rate=gst_rate,
-                            quantity=qty,
-                            rate=rate,
-                            cgst=cgst,
-                            sgst=sgst,
-                            igst=igst,
-                            amount=amount,
-                            workspace_id=1,
-                        ))
-
-                    audit_logs_to_create.append(AuditLog(
-                        action="imported",
-                        entity="invoice",
-                        entity_id=invoice.pk,
-                        entity_name=f"#{invoice.invoice_number} - {customer.name}",
-                        user=request.user if request.user and request.user.is_authenticated else None,
-                        details=f"Imported from Excel ({len(items)} items, total: {invoice.total_amount})",
-                    ))
-
                     created_count += 1
 
                 except Exception as e:
@@ -2338,13 +2335,99 @@ class BulkInvoiceImportView(APIView):
                     skipped_count += 1
 
             # ---------- PHASE 3: bulk writes ----------
+            # Bulk-create invoices in ONE round-trip. PostgreSQL fills in PKs.
+            if invoices_to_create:
+                invoice_objs = [pair[0] for pair in invoices_to_create]
+                Invoice.objects.bulk_create(invoice_objs, batch_size=200)
+                # Now invoice.pk is populated; build line items + audit logs.
+                for invoice, inv_data in invoices_to_create:
+                    items = inv_data.get("items", [])
+                    is_igst = invoice.is_igst_applicable
+                    for item in items:
+                        qty = Decimal(str(item.get("qty", 0)))
+                        rate = Decimal(str(item.get("rate", 0)))
+                        gst_rate = Decimal(str(item.get("gstRate", 3))) / Decimal("100")
+                        net_amount = qty * rate
+                        tax_amount = net_amount * gst_rate
+                        cgst = Decimal(str(item.get("cgst", 0)))
+                        sgst = Decimal(str(item.get("sgst", 0)))
+                        igst = Decimal(str(item.get("igst", 0)))
+                        if cgst == 0 and sgst == 0 and igst == 0:
+                            if is_igst:
+                                igst = tax_amount
+                            else:
+                                cgst = tax_amount / 2
+                                sgst = tax_amount / 2
+                        amount = net_amount + cgst + sgst + igst
+                        line_items_to_create.append(LineItem(
+                            invoice=invoice, customer=invoice.customer,
+                            product_name=item.get("productName", "Item"),
+                            hsn_code=item.get("hsn", "711319"),
+                            gst_tax_rate=gst_rate,
+                            quantity=qty, rate=rate,
+                            cgst=cgst, sgst=sgst, igst=igst, amount=amount,
+                            workspace_id=1,
+                        ))
+                    audit_logs_to_create.append(AuditLog(
+                        action="imported", entity="invoice",
+                        entity_id=invoice.pk,
+                        entity_name=f"#{invoice.invoice_number} - {invoice.customer.name}",
+                        user=request.user if request.user and request.user.is_authenticated else None,
+                        details=f"Imported from Excel ({len(items)} items, total: {invoice.total_amount})",
+                    ))
+
             if line_items_to_create:
                 LineItem.objects.bulk_create(line_items_to_create, batch_size=200)
+
+            # Safety net: recompute Invoice.total_amount from line items.
+            # bulk_create doesn't fire the post_save signal that normally keeps
+            # totals in sync. We trust the front-end-supplied total in inv_data
+            # but also re-sync to be defensive in case the payload was wrong.
+            if invoices_to_create:
+                from django.db.models import OuterRef, Subquery, Sum, DecimalField
+                invoice_ids = [inv.pk for inv, _ in invoices_to_create if inv.pk]
+                if invoice_ids:
+                    sub = (LineItem.objects
+                           .filter(invoice=OuterRef("pk"))
+                           .values("invoice")
+                           .annotate(s=Sum("amount"))
+                           .values("s"))
+                    Invoice.objects.filter(pk__in=invoice_ids).update(
+                        total_amount=Subquery(sub, output_field=DecimalField())
+                    )
+
+            # Add per-row error entries to the audit log so failures are
+            # visible in the UI's audit log page (not just Django logs).
+            if errors:
+                for err_msg in errors[:50]:  # cap to avoid runaway
+                    audit_logs_to_create.append(AuditLog(
+                        action="imported", entity="invoice",
+                        entity_id=0, entity_name="(failed row)",
+                        user=request.user if request.user and request.user.is_authenticated else None,
+                        details=f"Import error: {err_msg[:500]}",
+                    ))
+
             if audit_logs_to_create:
                 AuditLog.objects.bulk_create(audit_logs_to_create, batch_size=200)
-            # Link new customers to their businesses (M2M)
-            for cust, biz in new_customers_added_to_biz:
-                cust.businesses.add(biz)
+
+            # Link new customers to businesses via M2M — bulk_create the through-table
+            # rows instead of N individual .add() calls (each is its own round-trip).
+            if new_customers_added_to_biz:
+                Through = Customer.businesses.through
+                # Dedupe pairs (customer_id, business_id) — a customer might appear
+                # in multiple invoices for the same business.
+                seen_pairs = set()
+                m2m_rows = []
+                for cust, biz in new_customers_added_to_biz:
+                    if not cust.pk or not biz.pk:
+                        continue
+                    key = (cust.pk, biz.pk)
+                    if key in seen_pairs:
+                        continue
+                    seen_pairs.add(key)
+                    m2m_rows.append(Through(customer_id=cust.pk, business_id=biz.pk))
+                if m2m_rows:
+                    Through.objects.bulk_create(m2m_rows, ignore_conflicts=True, batch_size=200)
 
         return Response(
             {
@@ -2596,6 +2679,25 @@ class AuditLogViewSet(viewsets.ReadOnlyModelViewSet):
         if not model:
             return Response({"error": f"Unknown entity: {entry.entity}"}, status=400)
 
+        def _resolve_fk(field, raw_value):
+            """Resolve an FK snapshot value to an integer PK, even if older
+            audit entries stored the related object's __str__ (a name) rather
+            than the ID."""
+            if raw_value is None or raw_value == "None" or raw_value == "":
+                return None
+            try:
+                return int(raw_value)
+            except (TypeError, ValueError):
+                pass
+            # Older snapshots may have stored the __str__ — try a name lookup
+            related = field.related_model
+            for cand in ("name", "invoice_number", "username"):
+                if hasattr(related, cand):
+                    obj = related.objects.filter(**{cand: raw_value}).first()
+                    if obj:
+                        return obj.pk
+            return None
+
         try:
             if entry.action == "deleted" and entry.snapshot:
                 # Recreate the deleted object
@@ -2609,8 +2711,8 @@ class AuditLogViewSet(viewsets.ReadOnlyModelViewSet):
                     if v is None or v == "None":
                         kwargs[k] = None if field.null else ""
                     elif hasattr(field, "related_model") and field.related_model:
-                        # FK field — store the raw ID
-                        kwargs[k + "_id"] = int(v) if v else None
+                        # FK field — resolve to integer PK (handles new + legacy snapshots)
+                        kwargs[k + "_id"] = _resolve_fk(field, v)
                     else:
                         kwargs[k] = v
                 obj = model.objects.create(**kwargs)
@@ -2638,7 +2740,7 @@ class AuditLogViewSet(viewsets.ReadOnlyModelViewSet):
                         continue
                     field = model._meta.get_field(k)
                     if hasattr(field, "related_model") and field.related_model:
-                        setattr(obj, k + "_id", int(v) if v and v != "None" else None)
+                        setattr(obj, k + "_id", _resolve_fk(field, v))
                     else:
                         if v is None or v == "None":
                             setattr(obj, k, None if field.null else "")

--- a/billing/models.py
+++ b/billing/models.py
@@ -280,7 +280,12 @@ class Invoice(AbstractBaseModel):
         return f"{self.invoice_number}_{self.customer.name}"
 
     def save(self, *args, **kwargs):
-        if self.pk:
+        # The post_save / post_delete signals on LineItem keep self.total_amount
+        # in sync (see billing/signals.py). Re-summing on every Invoice.save()
+        # was redundant and added a SELECT round-trip even on plain PATCHes that
+        # didn't touch line items. Callers that need a hard recalculation can
+        # pass `recalc_total=True` (e.g. data-fix scripts).
+        if self.pk and kwargs.pop("recalc_total", False):
             self.total_amount = sum(
                 LineItem.objects.filter(invoice=self).values_list("amount", flat=True)
             )

--- a/billing/models.py
+++ b/billing/models.py
@@ -285,7 +285,11 @@ class Invoice(AbstractBaseModel):
         # was redundant and added a SELECT round-trip even on plain PATCHes that
         # didn't touch line items. Callers that need a hard recalculation can
         # pass `recalc_total=True` (e.g. data-fix scripts).
-        if self.pk and kwargs.pop("recalc_total", False):
+        # NOTE: pop the kwarg UNCONDITIONALLY before the if — otherwise on a
+        # fresh-create (self.pk falsy), short-circuit eval skips the pop and
+        # the unknown kwarg leaks into super().save() → TypeError.
+        recalc = kwargs.pop("recalc_total", False)
+        if self.pk and recalc:
             self.total_amount = sum(
                 LineItem.objects.filter(invoice=self).values_list("amount", flat=True)
             )

--- a/e2e-tests/package-lock.json
+++ b/e2e-tests/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "gst-billing-e2e-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gst-billing-e2e-tests",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.59.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "gst-billing-e2e-tests",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Playwright E2E suite for the GST Billing app. Run separately from the frontend.",
+  "scripts": {
+    "test": "playwright test --reporter=list"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.59.1"
+  }
+}

--- a/e2e-tests/playwright.config.js
+++ b/e2e-tests/playwright.config.js
@@ -3,7 +3,7 @@ module.exports = {
   timeout: 90000,
   reporter: [['list'], ['json', { outputFile: 'results.json' }]],
   use: {
-    baseURL: 'http://localhost',
+    baseURL: process.env.BASE_URL || 'http://localhost:8080',
     headless: true,
     viewport: { width: 1280, height: 720 },
     screenshot: 'only-on-failure',

--- a/e2e-tests/playwright.config.js
+++ b/e2e-tests/playwright.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  testDir: './tests',
+  timeout: 90000,
+  reporter: [['list'], ['json', { outputFile: 'results.json' }]],
+  use: {
+    baseURL: 'http://localhost',
+    headless: true,
+    viewport: { width: 1280, height: 720 },
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+    actionTimeout: 15000,
+    navigationTimeout: 30000,
+  },
+  retries: 0,
+  workers: 1,
+  projects: [
+    { name: 'setup', testMatch: '**/_auth.setup.js' },
+    { name: 'main', testMatch: '**/*.spec.js', dependencies: ['setup'], use: { storageState: 'auth-state.json' } },
+  ],
+};

--- a/e2e-tests/tests/_auth.setup.js
+++ b/e2e-tests/tests/_auth.setup.js
@@ -1,0 +1,17 @@
+const { test } = require('@playwright/test');
+const path = require('path');
+
+test('authenticate', async ({ page }) => {
+  await page.goto('/');
+  await page.fill('input[type="text"], input[name="username"]', 'testuser');
+  await page.fill('input[type="password"]', 'testpass2026');
+  const responsePromise = page.waitForResponse(r => r.url().includes('/api/token/'));
+  await page.click('button[type="submit"]');
+  const tokenResp = await responsePromise;
+  if (tokenResp.status() !== 200) {
+    throw new Error(`Login failed: ${tokenResp.status()}`);
+  }
+  await page.waitForLoadState('networkidle', { timeout: 20000 });
+  await page.context().storageState({ path: path.join(__dirname, '..', 'auth-state.json') });
+  console.log('[AUTH] Saved auth state');
+});

--- a/e2e-tests/tests/crud.spec.js
+++ b/e2e-tests/tests/crud.spec.js
@@ -3,13 +3,14 @@ const { test, expect } = require('@playwright/test');
 test.describe('Invoice CRUD', () => {
   test('Create invoice via UI', async ({ page }) => {
     const t0 = Date.now();
-    await page.goto('/billing/invoice/new');
+    // Note: invoice creation route is /add (not /new like customer/business).
+    await page.goto('/billing/invoice/add');
     await page.waitForLoadState('networkidle');
     console.log(`[TIMING] Invoice form load: ${Date.now() - t0}ms`);
 
     // Assert the form actually rendered — guards against the route 500ing,
     // bouncing to /login, or shipping a blank shell.
-    await expect(page).toHaveURL(/\/billing\/invoice\/new/);
+    await expect(page).toHaveURL(/\/billing\/invoice\/add/);
     await expect(page.getByText(/invoice number|create invoice/i).first()).toBeVisible();
   });
 

--- a/e2e-tests/tests/crud.spec.js
+++ b/e2e-tests/tests/crud.spec.js
@@ -7,12 +7,10 @@ test.describe('Invoice CRUD', () => {
     await page.waitForLoadState('networkidle');
     console.log(`[TIMING] Invoice form load: ${Date.now() - t0}ms`);
 
-    // Try to find form fields and create
-    const t1 = Date.now();
-    // Look for any invoice creation success indicator
-    const html = await page.content();
-    const hasForm = html.toLowerCase().includes('invoice number') || html.toLowerCase().includes('create invoice');
-    console.log(`[TIMING] Invoice form has fields: ${hasForm} (${Date.now() - t1}ms)`);
+    // Assert the form actually rendered — guards against the route 500ing,
+    // bouncing to /login, or shipping a blank shell.
+    await expect(page).toHaveURL(/\/billing\/invoice\/new/);
+    await expect(page.getByText(/invoice number|create invoice/i).first()).toBeVisible();
   });
 
   test('Customer create flow', async ({ page }) => {
@@ -20,6 +18,9 @@ test.describe('Invoice CRUD', () => {
     await page.goto('/billing/customer/new');
     await page.waitForLoadState('networkidle');
     console.log(`[TIMING] Customer form load: ${Date.now() - t0}ms`);
+
+    await expect(page).toHaveURL(/\/billing\/customer\/new/);
+    await expect(page.getByText(/new customer|customer name|full name/i).first()).toBeVisible();
   });
 
   test('Business create flow', async ({ page }) => {
@@ -27,5 +28,8 @@ test.describe('Invoice CRUD', () => {
     await page.goto('/billing/business/new');
     await page.waitForLoadState('networkidle');
     console.log(`[TIMING] Business form load: ${Date.now() - t0}ms`);
+
+    await expect(page).toHaveURL(/\/billing\/business\/new/);
+    await expect(page.getByText(/new business|business name/i).first()).toBeVisible();
   });
 });

--- a/e2e-tests/tests/crud.spec.js
+++ b/e2e-tests/tests/crud.spec.js
@@ -1,0 +1,31 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Invoice CRUD', () => {
+  test('Create invoice via UI', async ({ page }) => {
+    const t0 = Date.now();
+    await page.goto('/billing/invoice/new');
+    await page.waitForLoadState('networkidle');
+    console.log(`[TIMING] Invoice form load: ${Date.now() - t0}ms`);
+
+    // Try to find form fields and create
+    const t1 = Date.now();
+    // Look for any invoice creation success indicator
+    const html = await page.content();
+    const hasForm = html.toLowerCase().includes('invoice number') || html.toLowerCase().includes('create invoice');
+    console.log(`[TIMING] Invoice form has fields: ${hasForm} (${Date.now() - t1}ms)`);
+  });
+
+  test('Customer create flow', async ({ page }) => {
+    const t0 = Date.now();
+    await page.goto('/billing/customer/new');
+    await page.waitForLoadState('networkidle');
+    console.log(`[TIMING] Customer form load: ${Date.now() - t0}ms`);
+  });
+
+  test('Business create flow', async ({ page }) => {
+    const t0 = Date.now();
+    await page.goto('/billing/business/new');
+    await page.waitForLoadState('networkidle');
+    console.log(`[TIMING] Business form load: ${Date.now() - t0}ms`);
+  });
+});

--- a/e2e-tests/tests/login.spec.js
+++ b/e2e-tests/tests/login.spec.js
@@ -20,7 +20,9 @@ test.describe('Auth flow', () => {
     await page.fill('input[name="username"], input[type="text"]', 'testuser');
     await page.fill('input[name="password"], input[type="password"]', 'testpass2026');
     await page.click('button[type="submit"]');
-    await page.waitForURL(/dashboard|invoice|home|^http:\/\/localhost\/?$/, { timeout: 15000 });
+    // Login.tsx navigates to "/" on success. Match any URL whose path is
+    // "/" (or contains dashboard/invoice/home) regardless of host:port.
+    await page.waitForURL((url) => url.pathname === '/' || /dashboard|invoice|home/.test(url.pathname), { timeout: 15000 });
     console.log(`[TIMING] Login submit + redirect: ${Date.now() - t0}ms`);
   });
 });

--- a/e2e-tests/tests/login.spec.js
+++ b/e2e-tests/tests/login.spec.js
@@ -10,7 +10,12 @@ test.describe('Auth flow', () => {
   test('Login page loads', async ({ page }) => {
     const t0 = Date.now();
     await page.goto('/');
-    await expect(page).toHaveURL(/login|\//);
+    // Anonymous user hitting "/" must end up on /login (ProtectedRoute guard).
+    // Assert pathname explicitly — `/login|\//` matched everything since every
+    // URL contains "/", which would silently pass on a broken redirect.
+    await expect(page).toHaveURL(/\/login$/);
+    // Sanity-check the form actually rendered, not just the route.
+    await expect(page.locator('input[type="password"]')).toBeVisible();
     console.log(`[TIMING] Login page load: ${Date.now() - t0}ms`);
   });
 

--- a/e2e-tests/tests/login.spec.js
+++ b/e2e-tests/tests/login.spec.js
@@ -1,0 +1,20 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Auth flow', () => {
+  test('Login page loads', async ({ page }) => {
+    const t0 = Date.now();
+    await page.goto('/');
+    await expect(page).toHaveURL(/login|\//);
+    console.log(`[TIMING] Login page load: ${Date.now() - t0}ms`);
+  });
+
+  test('Can log in as testuser', async ({ page }) => {
+    await page.goto('/');
+    const t0 = Date.now();
+    await page.fill('input[name="username"], input[type="text"]', 'testuser');
+    await page.fill('input[name="password"], input[type="password"]', 'testpass2026');
+    await page.click('button[type="submit"]');
+    await page.waitForURL(/dashboard|invoice|home|^http:\/\/localhost\/?$/, { timeout: 15000 });
+    console.log(`[TIMING] Login submit + redirect: ${Date.now() - t0}ms`);
+  });
+});

--- a/e2e-tests/tests/login.spec.js
+++ b/e2e-tests/tests/login.spec.js
@@ -1,6 +1,12 @@
 const { test, expect } = require('@playwright/test');
 
 test.describe('Auth flow', () => {
+  // Opt out of the stored auth state from _auth.setup.js so this describe
+  // block exercises the actual login page. Without this, `storageState:
+  // 'auth-state.json'` keeps the user authenticated and `/` redirects past
+  // the login form, causing page.fill('input[name="username"]') to time out.
+  test.use({ storageState: { cookies: [], origins: [] } });
+
   test('Login page loads', async ({ page }) => {
     const t0 = Date.now();
     await page.goto('/');

--- a/e2e-tests/tests/navigation.spec.js
+++ b/e2e-tests/tests/navigation.spec.js
@@ -1,61 +1,28 @@
 const { test, expect } = require('@playwright/test');
 
+// Each test asserts URL + a known heading/text so a 500, blank shell, or
+// silent /login bounce fails the test instead of passing on networkidle alone.
+const routes = [
+  { name: 'Dashboard',      path: '/',                       text: /dashboard|welcome|recent invoices/i },
+  { name: 'Invoice list',   path: '/billing/invoice/list',   text: /invoices/i },
+  { name: 'Customer list',  path: '/billing/customer/list',  text: /customers/i },
+  { name: 'Business list',  path: '/billing/business/list',  text: /businesses/i },
+  { name: 'Product list',   path: '/billing/product/list',   text: /products/i },
+  { name: 'GST Summary',    path: '/billing/gst-summary',    text: /gst summary|tax/i },
+  { name: 'Backup page',    path: '/billing/backup',         text: /backup|restore/i },
+  { name: 'Audit log',      path: '/billing/audit-log',      text: /audit log/i },
+];
+
 test.describe('Page navigation', () => {
-  test('Dashboard loads', async ({ page }) => {
-    const t0 = Date.now();
-    await page.goto('/');
-    await page.waitForLoadState('networkidle');
-    console.log(`[TIMING] Dashboard load: ${Date.now() - t0}ms`);
-  });
+  for (const { name, path, text } of routes) {
+    test(`${name} loads`, async ({ page }) => {
+      const t0 = Date.now();
+      await page.goto(path);
+      await page.waitForLoadState('networkidle');
+      console.log(`[TIMING] ${name} load: ${Date.now() - t0}ms`);
 
-  test('Invoice list loads', async ({ page }) => {
-    const t0 = Date.now();
-    await page.goto('/billing/invoice/list');
-    await page.waitForLoadState('networkidle');
-    console.log(`[TIMING] Invoice list load: ${Date.now() - t0}ms`);
-    const html = await page.content();
-    expect(html.toLowerCase()).toContain('invoice');
-  });
-
-  test('Customer list loads', async ({ page }) => {
-    const t0 = Date.now();
-    await page.goto('/billing/customer/list');
-    await page.waitForLoadState('networkidle');
-    console.log(`[TIMING] Customer list load: ${Date.now() - t0}ms`);
-  });
-
-  test('Business list loads', async ({ page }) => {
-    const t0 = Date.now();
-    await page.goto('/billing/business/list');
-    await page.waitForLoadState('networkidle');
-    console.log(`[TIMING] Business list load: ${Date.now() - t0}ms`);
-  });
-
-  test('Product list loads', async ({ page }) => {
-    const t0 = Date.now();
-    await page.goto('/billing/product/list');
-    await page.waitForLoadState('networkidle');
-    console.log(`[TIMING] Product list load: ${Date.now() - t0}ms`);
-  });
-
-  test('GST Summary loads', async ({ page }) => {
-    const t0 = Date.now();
-    await page.goto('/billing/gst-summary');
-    await page.waitForLoadState('networkidle');
-    console.log(`[TIMING] GST Summary load: ${Date.now() - t0}ms`);
-  });
-
-  test('Backup page loads', async ({ page }) => {
-    const t0 = Date.now();
-    await page.goto('/billing/backup');
-    await page.waitForLoadState('networkidle');
-    console.log(`[TIMING] Backup load: ${Date.now() - t0}ms`);
-  });
-
-  test('Audit log loads', async ({ page }) => {
-    const t0 = Date.now();
-    await page.goto('/billing/audit-log');
-    await page.waitForLoadState('networkidle');
-    console.log(`[TIMING] Audit log load: ${Date.now() - t0}ms`);
-  });
+      await expect(page).toHaveURL(new RegExp(path.replace(/[/]/g, '\\/').replace(/^\\\//, '\\/?')));
+      await expect(page.getByText(text).first()).toBeVisible();
+    });
+  }
 });

--- a/e2e-tests/tests/navigation.spec.js
+++ b/e2e-tests/tests/navigation.spec.js
@@ -1,0 +1,61 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Page navigation', () => {
+  test('Dashboard loads', async ({ page }) => {
+    const t0 = Date.now();
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    console.log(`[TIMING] Dashboard load: ${Date.now() - t0}ms`);
+  });
+
+  test('Invoice list loads', async ({ page }) => {
+    const t0 = Date.now();
+    await page.goto('/billing/invoice/list');
+    await page.waitForLoadState('networkidle');
+    console.log(`[TIMING] Invoice list load: ${Date.now() - t0}ms`);
+    const html = await page.content();
+    expect(html.toLowerCase()).toContain('invoice');
+  });
+
+  test('Customer list loads', async ({ page }) => {
+    const t0 = Date.now();
+    await page.goto('/billing/customer/list');
+    await page.waitForLoadState('networkidle');
+    console.log(`[TIMING] Customer list load: ${Date.now() - t0}ms`);
+  });
+
+  test('Business list loads', async ({ page }) => {
+    const t0 = Date.now();
+    await page.goto('/billing/business/list');
+    await page.waitForLoadState('networkidle');
+    console.log(`[TIMING] Business list load: ${Date.now() - t0}ms`);
+  });
+
+  test('Product list loads', async ({ page }) => {
+    const t0 = Date.now();
+    await page.goto('/billing/product/list');
+    await page.waitForLoadState('networkidle');
+    console.log(`[TIMING] Product list load: ${Date.now() - t0}ms`);
+  });
+
+  test('GST Summary loads', async ({ page }) => {
+    const t0 = Date.now();
+    await page.goto('/billing/gst-summary');
+    await page.waitForLoadState('networkidle');
+    console.log(`[TIMING] GST Summary load: ${Date.now() - t0}ms`);
+  });
+
+  test('Backup page loads', async ({ page }) => {
+    const t0 = Date.now();
+    await page.goto('/billing/backup');
+    await page.waitForLoadState('networkidle');
+    console.log(`[TIMING] Backup load: ${Date.now() - t0}ms`);
+  });
+
+  test('Audit log loads', async ({ page }) => {
+    const t0 = Date.now();
+    await page.goto('/billing/audit-log');
+    await page.waitForLoadState('networkidle');
+    console.log(`[TIMING] Audit log load: ${Date.now() - t0}ms`);
+  });
+});

--- a/e2e-tests/tests/utils.js
+++ b/e2e-tests/tests/utils.js
@@ -1,0 +1,13 @@
+function timed(label, fn) {
+  return async () => {
+    const t0 = Date.now();
+    try {
+      await fn();
+      console.log(`[TIMING] ${label}: ${Date.now() - t0}ms ✓`);
+    } catch (e) {
+      console.log(`[TIMING] ${label}: ${Date.now() - t0}ms ✗ (${e.message.split('\n')[0]})`);
+      throw e;
+    }
+  };
+}
+module.exports = { timed };

--- a/gst_billing/settings.py
+++ b/gst_billing/settings.py
@@ -15,7 +15,15 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
-from gst_billing import local
+# `local.py` holds dev secrets and is gitignored. In CI / fresh checkouts it
+# may not exist — fall back to env vars so settings can still load.
+try:
+    from gst_billing import local  # type: ignore[attr-defined]
+except ImportError:
+    class _LocalShim:
+        SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "django-insecure-dev-only")
+        DATABASES = None
+    local = _LocalShim()  # type: ignore[assignment]
 
 load_dotenv()
 

--- a/gst_billing/settings.py
+++ b/gst_billing/settings.py
@@ -16,12 +16,24 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 # `local.py` holds dev secrets and is gitignored. In CI / fresh checkouts it
-# may not exist — fall back to env vars so settings can still load.
+# may not exist — fall back to env vars so settings can still load. The
+# fallback never picks an insecure default in non-DEBUG environments: if
+# DJANGO_SECRET_KEY is unset and DEBUG isn't truthy, we raise so a misconfigured
+# deploy fails loudly instead of running with a known key.
 try:
     from gst_billing import local  # type: ignore[attr-defined]
 except ImportError:
+    _env_key = os.environ.get("DJANGO_SECRET_KEY")
+    _debug_env = os.environ.get("DEBUG", "").lower() in ("1", "true", "yes")
+    if not _env_key and not _debug_env:
+        raise RuntimeError(
+            "gst_billing/local.py is missing and DJANGO_SECRET_KEY is not set. "
+            "Set DJANGO_SECRET_KEY (or create local.py) before starting Django "
+            "in a non-DEBUG environment."
+        )
+
     class _LocalShim:
-        SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "django-insecure-dev-only")
+        SECRET_KEY = _env_key or "django-insecure-dev-only"
         DATABASES = None
     local = _LocalShim()  # type: ignore[assignment]
 

--- a/gst_billing/settings.py
+++ b/gst_billing/settings.py
@@ -269,6 +269,10 @@ if REDIS_PASSWORD:
 
 # AI Configuration
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
+# Ensure log dir exists — django.utils.log.configure_logging will fail to
+# attach the FileHandler otherwise (fresh checkouts and CI runners).
+os.makedirs(os.path.join(BASE_DIR, "logs"), exist_ok=True)
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -296,7 +300,7 @@ LOGGING = {
         "file": {
             "level": "DEBUG",
             "class": "logging.FileHandler",
-            "filename": os.path.join(BASE_DIR, "logs/django.log"),
+            "filename": os.path.join(BASE_DIR, "logs", "django.log"),
             "formatter": "verbose",
         },
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,10 +48,14 @@ dev = [
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-# Explicit list — repo has several top-level dirs (frontend, nginx, etc.)
-# that aren't Python packages, so flat auto-detection fails.
-packages = ["billing", "gst_billing"]
+# Use setuptools package discovery scoped to our two top-level Python
+# packages. The repo has several non-Python top-level dirs (frontend,
+# nginx, sweet-rebuild-suite-main, etc.) so flat auto-detection fails;
+# `include` keeps it scoped while still picking up subpackages like
+# billing.api, billing.management, billing.management.commands, etc.
+[tool.setuptools.packages.find]
+include = ["billing*", "gst_billing*"]
+exclude = ["billing.tests*", "node_modules*"]
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "gst_billing.test_settings"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,15 @@ dev = [
     "flake8",
 ]
 
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+# Explicit list — repo has several top-level dirs (frontend, nginx, etc.)
+# that aren't Python packages, so flat auto-detection fails.
+packages = ["billing", "gst_billing"]
+
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "gst_billing.test_settings"
 python_files = "test_*.py"

--- a/sweet-rebuild-suite-main/package-lock.json
+++ b/sweet-rebuild-suite-main/package-lock.json
@@ -78,6 +78,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/typography": "^0.5.16",
         "@testing-library/jest-dom": "^6.6.0",
         "@testing-library/react": "^16.0.0",
@@ -1273,6 +1274,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -7894,6 +7911,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {

--- a/sweet-rebuild-suite-main/package-lock.json
+++ b/sweet-rebuild-suite-main/package-lock.json
@@ -78,7 +78,6 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
-        "@playwright/test": "^1.59.1",
         "@tailwindcss/typography": "^0.5.16",
         "@testing-library/jest-dom": "^6.6.0",
         "@testing-library/react": "^16.0.0",
@@ -1274,22 +1273,6 @@
       "optional": true,
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright": "1.59.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -7911,53 +7894,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.59.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {

--- a/sweet-rebuild-suite-main/package.json
+++ b/sweet-rebuild-suite-main/package.json
@@ -83,6 +83,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/typography": "^0.5.16",
     "@testing-library/jest-dom": "^6.6.0",
     "@testing-library/react": "^16.0.0",

--- a/sweet-rebuild-suite-main/package.json
+++ b/sweet-rebuild-suite-main/package.json
@@ -83,7 +83,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",
-    "@playwright/test": "^1.59.1",
     "@tailwindcss/typography": "^0.5.16",
     "@testing-library/jest-dom": "^6.6.0",
     "@testing-library/react": "^16.0.0",

--- a/sweet-rebuild-suite-main/src/components/EwayBillForm.tsx
+++ b/sweet-rebuild-suite-main/src/components/EwayBillForm.tsx
@@ -3,6 +3,7 @@ import { Truck, Save, X, Loader2, FileText } from "lucide-react";
 import { motion } from "framer-motion";
 import { useToast } from "@/hooks/use-toast";
 import api from "@/utils/api";
+import { formatApiError, errorTag } from "@/utils/apiError";
 
 interface Props {
   invoiceId: string;
@@ -50,7 +51,7 @@ export default function EwayBillForm({ invoiceId, onClose, onSaved }: Props) {
       onSaved?.();
       onClose();
     } catch (err: any) {
-      toast({ title: "Save Failed", description: err?.response?.data?.error || "Could not save", variant: "destructive" });
+      toast({ title: `Save Failed ${errorTag(err)}`, description: formatApiError(err, "Could not save"), variant: "destructive", duration: 12000 });
     }
     setSaving(false);
   };

--- a/sweet-rebuild-suite-main/src/components/QuickCustomerModal.tsx
+++ b/sweet-rebuild-suite-main/src/components/QuickCustomerModal.tsx
@@ -5,6 +5,7 @@ import { indianStates } from "@/utils/mockData";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/utils/utils";
 import { useCustomers, useBusinesses } from "@/hooks/useDataStore";
+import { formatApiError, errorTag } from "@/utils/apiError";
 
 interface QuickCustomerModalProps {
   open: boolean;
@@ -84,14 +85,7 @@ export default function QuickCustomerModal({ open, onClose, onCreated }: QuickCu
       setForm({ name: "", gst: "", pan: "", mobile: "", email: "", state: "", address: "" });
       setErrors({});
     } catch (err: any) {
-      const detail = err?.response?.data;
-      let errorMsg = "Could not create customer. Please try again.";
-      if (detail && typeof detail === "object") {
-        errorMsg = Object.entries(detail)
-          .map(([key, val]) => `${key}: ${Array.isArray(val) ? val.join(", ") : val}`)
-          .join("\n");
-      }
-      toast({ title: "Creation Failed", description: errorMsg, variant: "destructive" });
+      toast({ title: `Creation Failed ${errorTag(err)}`, description: formatApiError(err, "Could not create customer."), variant: "destructive", duration: 12000 });
     }
     setSubmitting(false);
   };

--- a/sweet-rebuild-suite-main/src/pages/AIInvoiceImport.tsx
+++ b/sweet-rebuild-suite-main/src/pages/AIInvoiceImport.tsx
@@ -56,23 +56,23 @@ export default function AIInvoiceImport() {
       </div>
 
       {/* Steps Indicator */}
-      <div className="elevated-card rounded-2xl p-4">
-        <div className="flex items-center gap-3">
+      <div className="elevated-card rounded-2xl p-3 sm:p-4">
+        <div className="flex items-center gap-1.5 sm:gap-3">
           {[{ n: 1, label: "Upload Image", icon: Upload }, { n: 2, label: "AI Processing", icon: Sparkles }, { n: 3, label: "Review & Create", icon: CheckCircle }].map((s, i) => (
-            <div key={s.n} className="flex items-center gap-2.5 flex-1">
-              <div className={cn("flex items-center gap-2.5 flex-1 p-3 rounded-xl transition-all",
+            <div key={s.n} className="flex items-center gap-1.5 sm:gap-2.5 flex-1 min-w-0">
+              <div className={cn("flex items-center gap-1.5 sm:gap-2.5 flex-1 min-w-0 p-2 sm:p-3 rounded-xl transition-all",
                 step === s.n ? "bg-primary/10 border border-primary/20" : step > s.n ? "bg-success/5 border border-success/20" : "border border-transparent"
               )}>
-                <div className={cn("w-8 h-8 rounded-xl flex items-center justify-center text-[13px] font-bold transition-all shrink-0",
+                <div className={cn("w-7 h-7 sm:w-8 sm:h-8 rounded-xl flex items-center justify-center text-[12px] sm:text-[13px] font-bold transition-all shrink-0",
                   step > s.n ? "bg-success text-success-foreground" : step === s.n ? "bg-primary text-primary-foreground glow-sm" : "bg-secondary/50 text-muted-foreground"
                 )}>
                   {step > s.n ? <CheckCircle className="w-4 h-4" /> : s.n}
                 </div>
-                <div className="min-w-0">
-                  <p className={cn("text-[12px] font-semibold", step >= s.n ? "text-foreground" : "text-muted-foreground")}>{s.label}</p>
+                <div className="min-w-0 flex-1">
+                  <p className={cn("text-[11px] sm:text-[12px] font-semibold truncate", step >= s.n ? "text-foreground" : "text-muted-foreground")}>{s.label}</p>
                 </div>
               </div>
-              {i < 2 && <ArrowRight className="w-3.5 h-3.5 text-muted-foreground shrink-0" />}
+              {i < 2 && <ArrowRight className="w-3 h-3 sm:w-3.5 sm:h-3.5 text-muted-foreground shrink-0" />}
             </div>
           ))}
         </div>

--- a/sweet-rebuild-suite-main/src/pages/AIInvoiceImport.tsx
+++ b/sweet-rebuild-suite-main/src/pages/AIInvoiceImport.tsx
@@ -68,7 +68,7 @@ export default function AIInvoiceImport() {
                 )}>
                   {step > s.n ? <CheckCircle className="w-4 h-4" /> : s.n}
                 </div>
-                <div className="min-w-0 flex-1">
+                <div className={cn("min-w-0 flex-1", step !== s.n && "hidden sm:block")}>
                   <p className={cn("text-[11px] sm:text-[12px] font-semibold truncate", step >= s.n ? "text-foreground" : "text-muted-foreground")}>{s.label}</p>
                 </div>
               </div>

--- a/sweet-rebuild-suite-main/src/pages/BatchPrint.tsx
+++ b/sweet-rebuild-suite-main/src/pages/BatchPrint.tsx
@@ -180,12 +180,20 @@ export default function BatchPrint() {
 
   if (invoiceIds.length === 0) {
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center p-8 space-y-4">
-        <FileText className="w-12 h-12 text-muted-foreground opacity-30" />
-        <p className="text-sm font-medium text-muted-foreground">No invoices selected for batch print.</p>
-        <Link to="/billing/invoice/list" className="premium-btn-ghost text-sm">
-          <ArrowLeft className="w-4 h-4" /> Back to Invoices
-        </Link>
+      <div className="min-h-screen bg-background flex flex-col">
+        <div className={cn("no-print flex items-center gap-2 border-b border-border bg-card", isMobile ? "px-4 py-3" : "px-8 py-4 gap-3")}>
+          <Link to="/billing/invoice/list" className="text-[12px] text-muted-foreground hover:text-foreground flex items-center gap-1">
+            <ArrowLeft className="w-4 h-4" /> Back
+          </Link>
+          <span className={cn("font-display font-semibold text-foreground", isMobile ? "text-[13px]" : "text-[14px] ml-2")}>Batch Print</span>
+        </div>
+        <div className="flex-1 flex flex-col items-center justify-center p-8 space-y-4">
+          <FileText className="w-12 h-12 text-muted-foreground opacity-30" />
+          <p className="text-sm font-medium text-muted-foreground">No invoices selected for batch print.</p>
+          <Link to="/billing/invoice/list" className="premium-btn-ghost text-sm">
+            <ArrowLeft className="w-4 h-4" /> Back to Invoices
+          </Link>
+        </div>
       </div>
     );
   }

--- a/sweet-rebuild-suite-main/src/pages/BulkPDF.tsx
+++ b/sweet-rebuild-suite-main/src/pages/BulkPDF.tsx
@@ -22,14 +22,9 @@ import QRCode from "qrcode";
 export default function BulkPDF() {
   const { toast } = useToast();
   const navigate = useNavigate();
-  // Default to current month and year
-  const now = new Date();
-  const currentMonthIndex = now.getMonth(); // 0-based (0=Jan)
   const MONTHS = ["April", "May", "June", "July", "August", "September", "October", "November", "December", "January", "February", "March"];
-  // Map JS month (0-11) to FY month name
-  const fyMonthMap: Record<number, string> = { 3: "April", 4: "May", 5: "June", 6: "July", 7: "August", 8: "September", 9: "October", 10: "November", 11: "December", 0: "January", 1: "February", 2: "March" };
-  const defaultMonth = fyMonthMap[currentMonthIndex] || "April";
-  const [month, setMonth] = useState(defaultMonth);
+  // Default to "all" so the page lands with results visible instead of an empty current month.
+  const [month, setMonth] = useState("all");
   const [selectedFY, setSelectedFY] = useState(currentFY);
   const [bizFilter, setBizFilter] = useState("all");
   const [typeFilter, setTypeFilter] = useState("all");

--- a/sweet-rebuild-suite-main/src/pages/BusinessDetail.tsx
+++ b/sweet-rebuild-suite-main/src/pages/BusinessDetail.tsx
@@ -117,22 +117,22 @@ export default function BusinessDetail() {
               { label: "Address", value: biz.address },
             ].map((f) => (
               <div key={f.label} className="flex items-start justify-between">
-                <div><p className="text-[10px] text-muted-foreground uppercase">{f.label}</p><p className="text-[13px] text-foreground">{f.value}</p></div>
-                {f.copyable && <button onClick={() => copyToClipboard(f.value, f.label)} className="mt-2 text-muted-foreground hover:text-foreground">{copiedField === f.label ? <CheckCircle2 className="w-3.5 h-3.5 text-success" /> : <Copy className="w-3.5 h-3.5" />}</button>}
+                <div><p className="text-[10px] text-muted-foreground uppercase">{f.label}</p><p className="text-[13px] text-foreground">{f.value || "—"}</p></div>
+                {f.copyable && f.value && <button onClick={() => copyToClipboard(f.value, f.label)} className="mt-2 text-muted-foreground hover:text-foreground">{copiedField === f.label ? <CheckCircle2 className="w-3.5 h-3.5 text-success" /> : <Copy className="w-3.5 h-3.5" />}</button>}
               </div>
             ))}
           </div>
           {/* Contact */}
           <div className="elevated-card rounded-2xl p-5 space-y-3">
             <h2 className="text-xs font-display font-semibold text-muted-foreground uppercase tracking-wider">Contact</h2>
-            <div><p className="text-[10px] text-muted-foreground uppercase">Phone</p><p className="text-[13px] text-foreground tabular-nums">{biz.mobile_number}</p></div>
-            <div><p className="text-[10px] text-muted-foreground uppercase">Email</p><p className="text-[13px] text-foreground">{biz.email}</p></div>
+            <div><p className="text-[10px] text-muted-foreground uppercase">Phone</p><p className="text-[13px] text-foreground tabular-nums">{biz.mobile_number || "—"}</p></div>
+            <div><p className="text-[10px] text-muted-foreground uppercase">Email</p><p className="text-[13px] text-foreground">{biz.email || "—"}</p></div>
           </div>
           {/* Bank */}
           <div className="elevated-card rounded-2xl p-5 space-y-3">
             <h2 className="text-xs font-display font-semibold text-muted-foreground uppercase tracking-wider">Bank Details</h2>
             {[{ label: "Bank", value: biz.bank_name }, { label: "Account", value: biz.bank_account_number }, { label: "IFSC", value: biz.bank_ifsc_code }, { label: "Branch", value: biz.bank_branch_name }].map((f) => (
-              <div key={f.label}><p className="text-[10px] text-muted-foreground uppercase">{f.label}</p><p className="text-[13px] text-foreground">{f.value}</p></div>
+              <div key={f.label}><p className="text-[10px] text-muted-foreground uppercase">{f.label}</p><p className="text-[13px] text-foreground">{f.value || "—"}</p></div>
             ))}
           </div>
         </div>

--- a/sweet-rebuild-suite-main/src/pages/BusinessForm.tsx
+++ b/sweet-rebuild-suite-main/src/pages/BusinessForm.tsx
@@ -10,6 +10,7 @@ import {
 import { motion, AnimatePresence } from "framer-motion";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/utils/utils";
+import { formatApiError, errorTag } from "@/utils/apiError";
 
 const fadeUp = {
   hidden: { opacity: 0, y: 16 },
@@ -162,14 +163,7 @@ export default function BusinessForm() {
       setDirty(false);
       navigate("/billing/business/list");
     } catch (err: any) {
-      const detail = err?.response?.data;
-      let errorMsg = "Something went wrong. Please try again.";
-      if (detail && typeof detail === "object") {
-        errorMsg = Object.entries(detail)
-          .map(([key, val]) => `${key}: ${Array.isArray(val) ? val.join(", ") : val}`)
-          .join("\n");
-      }
-      toast({ title: "Save Failed", description: errorMsg, variant: "destructive" });
+      toast({ title: `Save Failed ${errorTag(err)}`, description: formatApiError(err, "Could not save business."), variant: "destructive", duration: 12000 });
     }
   };
 

--- a/sweet-rebuild-suite-main/src/pages/BusinessList.tsx
+++ b/sweet-rebuild-suite-main/src/pages/BusinessList.tsx
@@ -59,7 +59,7 @@ export default function BusinessList() {
   };
 
   return (
-    <div className={cn("space-y-5 max-w-[1440px] mx-auto", isMobile ? "p-4 pb-24" : "p-6 lg:p-10 space-y-6")}>
+    <div className={cn("space-y-5 max-w-[1440px] mx-auto", isMobile ? "p-4 pb-40" : "p-6 lg:p-10 space-y-6")}>
       <Breadcrumbs items={[{ label: "Businesses" }]} />
 
       {/* Header */}

--- a/sweet-rebuild-suite-main/src/pages/CustomerDetail.tsx
+++ b/sweet-rebuild-suite-main/src/pages/CustomerDetail.tsx
@@ -168,7 +168,7 @@ export default function CustomerDetail() {
             ].map((f) => (
               <div key={f.label} className="flex items-center gap-3 p-2 rounded-xl">
                 <f.icon className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
-                <div className="min-w-0"><p className="text-[10px] text-muted-foreground uppercase">{f.label}</p><p className="text-[13px] text-foreground truncate">{f.value}</p></div>
+                <div className="min-w-0"><p className="text-[10px] text-muted-foreground uppercase">{f.label}</p><p className="text-[13px] text-foreground truncate">{f.value || "—"}</p></div>
               </div>
             ))}
           </div>
@@ -178,10 +178,12 @@ export default function CustomerDetail() {
             <h2 className="text-xs font-display font-semibold text-foreground uppercase tracking-wider">Tax Info</h2>
             {[{ label: "GST", value: customer.gst_number }, { label: "PAN", value: customer.pan_number }].map((f) => (
               <div key={f.label} className="flex items-center justify-between p-2.5 rounded-xl bg-secondary/15 border border-border/30">
-                <div><p className="text-[10px] text-muted-foreground uppercase">{f.label}</p><code className="text-[12px] font-mono text-foreground">{f.value}</code></div>
-                <button onClick={() => copyToClipboard(f.value, f.label)} className="w-7 h-7 rounded-lg flex items-center justify-center text-muted-foreground hover:text-foreground">
-                  {copiedField === f.label ? <CheckCircle2 className="w-3.5 h-3.5 text-success" /> : <Copy className="w-3.5 h-3.5" />}
-                </button>
+                <div><p className="text-[10px] text-muted-foreground uppercase">{f.label}</p><code className="text-[12px] font-mono text-foreground">{f.value || "—"}</code></div>
+                {f.value && (
+                  <button onClick={() => copyToClipboard(f.value, f.label)} className="w-7 h-7 rounded-lg flex items-center justify-center text-muted-foreground hover:text-foreground">
+                    {copiedField === f.label ? <CheckCircle2 className="w-3.5 h-3.5 text-success" /> : <Copy className="w-3.5 h-3.5" />}
+                  </button>
+                )}
               </div>
             ))}
           </div>

--- a/sweet-rebuild-suite-main/src/pages/CustomerForm.tsx
+++ b/sweet-rebuild-suite-main/src/pages/CustomerForm.tsx
@@ -11,6 +11,7 @@ import {
 import { motion, AnimatePresence } from "framer-motion";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/utils/utils";
+import { formatApiError, errorTag } from "@/utils/apiError";
 
 const fadeUp = {
   hidden: { opacity: 0, y: 16 },
@@ -177,14 +178,7 @@ export default function CustomerForm() {
       setDirty(false);
       navigate("/billing/customer/list");
     } catch (err: any) {
-      const detail = err?.response?.data;
-      let errorMsg = "Something went wrong. Please try again.";
-      if (detail && typeof detail === "object") {
-        errorMsg = Object.entries(detail)
-          .map(([key, val]) => `${key}: ${Array.isArray(val) ? val.join(", ") : val}`)
-          .join("\n");
-      }
-      toast({ title: "Save Failed", description: errorMsg, variant: "destructive" });
+      toast({ title: `Save Failed ${errorTag(err)}`, description: formatApiError(err, "Could not save customer."), variant: "destructive", duration: 12000 });
     }
   };
 
@@ -218,9 +212,10 @@ export default function CustomerForm() {
       navigate(`/billing/customer/${mergeTarget}`);
     } catch (err: any) {
       toast({
-        title: "Merge Failed",
-        description: err?.response?.data?.error || "Could not merge customers.",
+        title: `Merge Failed ${errorTag(err)}`,
+        description: formatApiError(err, "Could not merge customers."),
         variant: "destructive",
+        duration: 12000,
       });
     }
   };

--- a/sweet-rebuild-suite-main/src/pages/CustomerList.tsx
+++ b/sweet-rebuild-suite-main/src/pages/CustomerList.tsx
@@ -76,7 +76,7 @@ export default function CustomerList() {
   // ─── MOBILE VIEW ───
   if (isMobile) {
     return (
-      <div className="p-4 space-y-4">
+      <div className="p-4 pb-40 space-y-4">
         <div>
           <h1 className="text-2xl font-display font-bold text-foreground tracking-tight">Customers</h1>
           <p className="text-xs text-muted-foreground mt-0.5">{totalCustomers}</p>

--- a/sweet-rebuild-suite-main/src/pages/CustomerList.tsx
+++ b/sweet-rebuild-suite-main/src/pages/CustomerList.tsx
@@ -15,6 +15,7 @@ import DeleteConfirmDialog from "@/components/DeleteConfirmDialog";
 import { useIsMobile } from "@/hooks/use-mobile";
 import MobileFilterSheet from "@/components/mobile/MobileFilterSheet";
 import { stagger, fadeUp } from "@/utils/animations";
+import { formatApiError, errorTag } from "@/utils/apiError";
 
 export default function CustomerList() {
   const { toast } = useToast();
@@ -570,9 +571,10 @@ export default function CustomerList() {
               navigate(`/billing/customer/${mergeTarget}`);
             } catch (err: any) {
               toast({
-                title: "Merge Failed",
-                description: err?.response?.data?.error || "Could not merge customers.",
+                title: `Merge Failed ${errorTag(err)}`,
+                description: formatApiError(err, "Could not merge customers."),
                 variant: "destructive",
+                duration: 12000,
               });
             }
           };

--- a/sweet-rebuild-suite-main/src/pages/CustomerStatement.tsx
+++ b/sweet-rebuild-suite-main/src/pages/CustomerStatement.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useParams, Link } from "react-router-dom";
-import { formatCurrency, formatDate } from "@/utils/mockData";
+import { formatCurrency, formatDate, currentFY } from "@/utils/mockData";
 import Breadcrumbs from "@/components/Breadcrumbs";
 import { ArrowLeft, Printer, Calendar, FileText, TrendingUp, TrendingDown, Scale, Hash, MapPin, Building2, Receipt, Download } from "lucide-react";
 import { downloadStatementPDF } from "@/utils/generateStatementPDF";
@@ -19,8 +19,9 @@ export default function CustomerStatement() {
   const { items: businesses } = useBusinesses();
   const isMobile = useIsMobile();
   const customer = customers.find((c) => String(c.id) === String(id));
-  const [startDate, setStartDate] = useState("2024-04-01");
-  const [endDate, setEndDate] = useState("2025-03-31");
+  const _fyStartYear = parseInt(currentFY.split("-")[0], 10);
+  const [startDate, setStartDate] = useState(`${_fyStartYear}-04-01`);
+  const [endDate, setEndDate] = useState(`${_fyStartYear + 1}-03-31`);
   const [bizFilter, setBizFilter] = useState("all");
 
   if (!customer) return <div className="p-8 text-muted-foreground">Customer not found.</div>;

--- a/sweet-rebuild-suite-main/src/pages/GSTRExport.tsx
+++ b/sweet-rebuild-suite-main/src/pages/GSTRExport.tsx
@@ -6,7 +6,7 @@ import Breadcrumbs from "@/components/Breadcrumbs";
 import { formatCurrency, financialYears } from "@/utils/mockData";
 import { useBusinesses } from "@/hooks/useDataStore";
 import { useToast } from "@/hooks/use-toast";
-import { cn } from "@/utils/utils";
+import { cn, pluralize } from "@/utils/utils";
 import { motion } from "framer-motion";
 import api from "@/utils/api";
 
@@ -124,7 +124,7 @@ export default function GSTRExport() {
 
                 {/* B2B Summary */}
                 <div className="space-y-2">
-                  <h4 className="text-[12px] font-semibold text-muted-foreground uppercase tracking-wider">B2B — Registered Dealers ({gstr1.b2b?.length || 0} parties)</h4>
+                  <h4 className="text-[12px] font-semibold text-muted-foreground uppercase tracking-wider">B2B — Registered Dealers ({pluralize(gstr1.b2b?.length || 0, "party", "parties")})</h4>
                   {(gstr1.b2b || []).length > 0 ? (
                     <div className="overflow-x-auto"><table className="table-premium text-[12px] min-w-[480px]">
                       <thead><tr><th>GSTIN</th><th className="text-right">Invoices</th><th className="text-right">Total Value</th></tr></thead>
@@ -143,7 +143,7 @@ export default function GSTRExport() {
 
                 {/* B2CS Summary */}
                 <div className="space-y-2">
-                  <h4 className="text-[12px] font-semibold text-muted-foreground uppercase tracking-wider">B2CS — Unregistered Intra-State ({gstr1.b2cs?.length || 0} entries)</h4>
+                  <h4 className="text-[12px] font-semibold text-muted-foreground uppercase tracking-wider">B2CS — Unregistered Intra-State ({pluralize(gstr1.b2cs?.length || 0, "entry", "entries")})</h4>
                   {(gstr1.b2cs || []).length > 0 ? (
                     <div className="overflow-x-auto"><table className="table-premium text-[12px] min-w-[480px]">
                       <thead><tr><th>State</th><th>Rate</th><th className="text-right">Taxable</th><th className="text-right">CGST</th><th className="text-right">SGST</th></tr></thead>
@@ -158,7 +158,7 @@ export default function GSTRExport() {
 
                 {/* HSN */}
                 <div className="space-y-2">
-                  <h4 className="text-[12px] font-semibold text-muted-foreground uppercase tracking-wider">HSN Summary ({gstr1.hsn?.data?.length || 0} codes)</h4>
+                  <h4 className="text-[12px] font-semibold text-muted-foreground uppercase tracking-wider">HSN Summary ({pluralize(gstr1.hsn?.data?.length || 0, "code")})</h4>
                   {(gstr1.hsn?.data || []).length > 0 ? (
                     <div className="overflow-x-auto"><table className="table-premium text-[12px] min-w-[480px]">
                       <thead><tr><th>HSN</th><th className="text-right">Qty</th><th className="text-right">Taxable</th><th className="text-right">CGST</th><th className="text-right">SGST</th><th className="text-right">IGST</th></tr></thead>

--- a/sweet-rebuild-suite-main/src/pages/GSTRExport.tsx
+++ b/sweet-rebuild-suite-main/src/pages/GSTRExport.tsx
@@ -126,7 +126,7 @@ export default function GSTRExport() {
                 <div className="space-y-2">
                   <h4 className="text-[12px] font-semibold text-muted-foreground uppercase tracking-wider">B2B — Registered Dealers ({gstr1.b2b?.length || 0} parties)</h4>
                   {(gstr1.b2b || []).length > 0 ? (
-                    <table className="table-premium text-[12px]">
+                    <div className="overflow-x-auto"><table className="table-premium text-[12px] min-w-[480px]">
                       <thead><tr><th>GSTIN</th><th className="text-right">Invoices</th><th className="text-right">Total Value</th></tr></thead>
                       <tbody>
                         {gstr1.b2b.map((party: any) => (
@@ -137,7 +137,7 @@ export default function GSTRExport() {
                           </tr>
                         ))}
                       </tbody>
-                    </table>
+                    </table></div>
                   ) : <p className="text-[12px] text-muted-foreground">No B2B invoices</p>}
                 </div>
 
@@ -145,14 +145,14 @@ export default function GSTRExport() {
                 <div className="space-y-2">
                   <h4 className="text-[12px] font-semibold text-muted-foreground uppercase tracking-wider">B2CS — Unregistered Intra-State ({gstr1.b2cs?.length || 0} entries)</h4>
                   {(gstr1.b2cs || []).length > 0 ? (
-                    <table className="table-premium text-[12px]">
+                    <div className="overflow-x-auto"><table className="table-premium text-[12px] min-w-[480px]">
                       <thead><tr><th>State</th><th>Rate</th><th className="text-right">Taxable</th><th className="text-right">CGST</th><th className="text-right">SGST</th></tr></thead>
                       <tbody>
                         {gstr1.b2cs.map((row: any, i: number) => (
                           <tr key={i}><td>{row.pos}</td><td>{row.rt}%</td><td className="text-right">{formatCurrency(row.txval)}</td><td className="text-right">{formatCurrency(row.camt)}</td><td className="text-right">{formatCurrency(row.samt)}</td></tr>
                         ))}
                       </tbody>
-                    </table>
+                    </table></div>
                   ) : <p className="text-[12px] text-muted-foreground">No B2CS invoices</p>}
                 </div>
 
@@ -160,14 +160,14 @@ export default function GSTRExport() {
                 <div className="space-y-2">
                   <h4 className="text-[12px] font-semibold text-muted-foreground uppercase tracking-wider">HSN Summary ({gstr1.hsn?.data?.length || 0} codes)</h4>
                   {(gstr1.hsn?.data || []).length > 0 ? (
-                    <table className="table-premium text-[12px]">
+                    <div className="overflow-x-auto"><table className="table-premium text-[12px] min-w-[480px]">
                       <thead><tr><th>HSN</th><th className="text-right">Qty</th><th className="text-right">Taxable</th><th className="text-right">CGST</th><th className="text-right">SGST</th><th className="text-right">IGST</th></tr></thead>
                       <tbody>
                         {gstr1.hsn.data.map((h: any) => (
                           <tr key={h.hsn_sc}><td className="font-mono">{h.hsn_sc}</td><td className="text-right">{h.qty.toFixed(3)}</td><td className="text-right">{formatCurrency(h.txval)}</td><td className="text-right">{formatCurrency(h.camt)}</td><td className="text-right">{formatCurrency(h.samt)}</td><td className="text-right">{formatCurrency(h.iamt)}</td></tr>
                         ))}
                       </tbody>
-                    </table>
+                    </table></div>
                   ) : <p className="text-[12px] text-muted-foreground">No HSN data</p>}
                 </div>
               </div>
@@ -182,7 +182,7 @@ export default function GSTRExport() {
                     <FileJson className="w-3.5 h-3.5" /> Download JSON
                   </button>
                 </div>
-                <table className="table-premium text-[13px]">
+                <div className="overflow-x-auto"><table className="table-premium text-[13px] min-w-[420px]">
                   <thead><tr><th></th><th className="text-right">CGST</th><th className="text-right">SGST</th><th className="text-right">IGST</th></tr></thead>
                   <tbody>
                     <tr>
@@ -204,7 +204,7 @@ export default function GSTRExport() {
                       <td className={cn("text-right", (gstr3b.tax_pmt?.igst || 0) >= 0 ? "text-destructive" : "text-success")}>{formatCurrency(Math.abs(gstr3b.tax_pmt?.igst || 0))}</td>
                     </tr>
                   </tbody>
-                </table>
+                </table></div>
               </div>
             )}
 
@@ -219,7 +219,7 @@ export default function GSTRExport() {
                 </div>
                 <p className="text-[12px] text-muted-foreground">{gstr2b.inward_invoices?.length || 0} inward invoices for matching</p>
                 {(gstr2b.inward_invoices || []).length > 0 ? (
-                  <table className="table-premium text-[12px]">
+                  <div className="overflow-x-auto"><table className="table-premium text-[12px] min-w-[640px]">
                     <thead><tr><th>Invoice #</th><th>Date</th><th>Supplier</th><th>GSTIN</th><th className="text-right">Taxable</th><th className="text-right">Tax</th><th className="text-right">Total</th></tr></thead>
                     <tbody>
                       {gstr2b.inward_invoices.map((inv: any, i: number) => (
@@ -234,7 +234,7 @@ export default function GSTRExport() {
                         </tr>
                       ))}
                     </tbody>
-                  </table>
+                  </table></div>
                 ) : <p className="text-[12px] text-muted-foreground">No inward invoices</p>}
               </div>
             )}

--- a/sweet-rebuild-suite-main/src/pages/GSTSummary.tsx
+++ b/sweet-rebuild-suite-main/src/pages/GSTSummary.tsx
@@ -217,7 +217,7 @@ export default function GSTSummary() {
         <div className={cn(isMobile ? "h-[160px]" : "h-[220px]")}>
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={monthlyTax} barGap={2}>
-              <XAxis dataKey="month" tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 10 }} axisLine={false} tickLine={false} />
+              <XAxis dataKey="month" tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 10 }} axisLine={false} tickLine={false} interval={0} tickFormatter={isMobile ? (v: string) => v.slice(0, 1) : undefined} />
               <YAxis tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 10 }} axisLine={false} tickLine={false} width={35} />
               <Tooltip contentStyle={{ background: "hsl(var(--card))", border: "1px solid hsl(var(--border))", borderRadius: 12, fontSize: 12, color: "hsl(var(--foreground))" }} itemStyle={{ color: "hsl(var(--foreground))" }} formatter={(value: number) => [`₹${value.toFixed(1)}k`, undefined]} />
               <Bar dataKey="output" name="Output" fill="hsl(var(--chart-1))" radius={[4, 4, 0, 0]}>

--- a/sweet-rebuild-suite-main/src/pages/ImportPage.tsx
+++ b/sweet-rebuild-suite-main/src/pages/ImportPage.tsx
@@ -59,22 +59,24 @@ const configs = {
     back: "/billing/invoice/list",
     breadcrumb: [{ label: "Invoices", href: "/billing/invoice/list" }, { label: "Import" }],
     columns: [
-      // The 3 truly required fields
+      // 7 required columns \u2014 no silent defaults; HSN + GST rate are resolved
+      // from the Product master via the Commodity name.
       { name: "Bill No.", required: true, example: "100", note: "" },
       { name: "Invoice Date", required: true, example: "06-02-2026", note: "DD-MM-YYYY" },
       { name: "Party Name", required: true, example: "Rajesh Kumar", note: "" },
-      // Plus EITHER (Qty + Rate) OR Total \u2014 at least one path to a price
-      { name: "Qty (gm)", required: true, example: "37.740", note: "+ Rate, OR use Total" },
+      { name: "GST Number", required: true, example: "08AABCK5461H1ZO", note: "blank cell allowed (= unregistered)" },
+      { name: "Commodity", required: true, example: "Gold Ornaments", note: "must match a product in your Product list" },
+      { name: "Qty (gm)", required: true, example: "37.740", note: "" },
       { name: "Rate (\u20b9/gm)", required: true, example: "16397.00", note: "" },
-      // Optional with smart defaults
-      { name: "GST Number", required: false, example: "08AABCK5461H1ZO", note: "blank = unregistered" },
-      { name: "Commodity", required: false, example: "Gold Ornaments", note: "default: Gold Ornaments" },
-      { name: "HSN Code", required: false, example: "711319", note: "default: 711319" },
-      { name: "GST Rate", required: false, example: "3%", note: "default: 3%" },
-      { name: "Total Invoice Value (\u20b9)", required: false, example: "637221.66", note: "auto-computed if blank" },
-      // Hidden / auto-computed \u2014 kept here so the parser still finds them if present
-      // CGST / SGST / IGST / Taxable Value are NOT shown in the UI list anymore;
-      // the parser computes them from the GST rate when they're missing.
+      // Auto-derived (won't be shown as required in UI, but parser reads them
+      // if the file does include them \u2014 useful when re-importing existing exports)
+      { name: "HSN Code", required: false, example: "711319", note: "from Product list" },
+      { name: "GST Rate", required: false, example: "3%", note: "from Product list" },
+      { name: "Taxable Value (\u20b9)", required: false, example: "618661.80", note: "= Qty \u00d7 Rate" },
+      { name: "CGST (\u20b9)", required: false, example: "9279.93", note: "computed" },
+      { name: "SGST (\u20b9)", required: false, example: "9279.93", note: "computed" },
+      { name: "IGST (\u20b9)", required: false, example: "0.00", note: "computed (inter-state)" },
+      { name: "Total Invoice Value (\u20b9)", required: false, example: "637221.66", note: "= Taxable + tax" },
     ],
     showBusiness: true,
     icon: Receipt,

--- a/sweet-rebuild-suite-main/src/pages/ImportPage.tsx
+++ b/sweet-rebuild-suite-main/src/pages/ImportPage.tsx
@@ -572,7 +572,10 @@ export default function ImportPage({ type }: ImportPageProps) {
         try {
           const data = e.target?.result as ArrayBuffer;
           const result = parseInvoiceExcel(data);
-          const invoices = toImportReadyInvoices(result);
+          const invoices = toImportReadyInvoices(
+            result,
+            (productsForTemplate || []).map((p: any) => ({ name: p.name, hsn_code: p.hsn_code, gst_tax_rate: p.gst_tax_rate })),
+          );
           if (invoices.length > 0) {
             toast({ title: "Excel Parsed", description: `Found ${invoices.length} invoices from ${result.firms.length} firm(s)` });
             // Navigate to full-screen review page

--- a/sweet-rebuild-suite-main/src/pages/ImportPage.tsx
+++ b/sweet-rebuild-suite-main/src/pages/ImportPage.tsx
@@ -59,21 +59,22 @@ const configs = {
     back: "/billing/invoice/list",
     breadcrumb: [{ label: "Invoices", href: "/billing/invoice/list" }, { label: "Import" }],
     columns: [
-      { name: "S.No.", required: false, example: "1" },
-      { name: "Bill No.", required: true, example: "100" },
-      { name: "Invoice Date", required: true, example: "06-02-2026" },
-      { name: "Party Name", required: true, example: "Rajesh Kumar" },
-      { name: "GST Number", required: false, example: "08AABCK5461H1ZO" },
-      { name: "Commodity", required: true, example: "Gold Ornaments" },
-      { name: "HSN Code", required: true, example: "711319" },
-      { name: "GST Rate", required: true, example: "3%" },
-      { name: "Qty (gm)", required: true, example: "37.740" },
-      { name: "Rate (\u20b9/gm)", required: true, example: "16397.00" },
-      { name: "Taxable Value (\u20b9)", required: false, example: "618661.80" },
-      { name: "CGST (\u20b9)", required: false, example: "9279.93" },
-      { name: "SGST (\u20b9)", required: false, example: "9279.93" },
-      { name: "IGST (\u20b9)", required: false, example: "0.00" },
-      { name: "Total Invoice Value (\u20b9)", required: false, example: "637221.66" },
+      // The 3 truly required fields
+      { name: "Bill No.", required: true, example: "100", note: "" },
+      { name: "Invoice Date", required: true, example: "06-02-2026", note: "DD-MM-YYYY" },
+      { name: "Party Name", required: true, example: "Rajesh Kumar", note: "" },
+      // Plus EITHER (Qty + Rate) OR Total \u2014 at least one path to a price
+      { name: "Qty (gm)", required: true, example: "37.740", note: "+ Rate, OR use Total" },
+      { name: "Rate (\u20b9/gm)", required: true, example: "16397.00", note: "" },
+      // Optional with smart defaults
+      { name: "GST Number", required: false, example: "08AABCK5461H1ZO", note: "blank = unregistered" },
+      { name: "Commodity", required: false, example: "Gold Ornaments", note: "default: Gold Ornaments" },
+      { name: "HSN Code", required: false, example: "711319", note: "default: 711319" },
+      { name: "GST Rate", required: false, example: "3%", note: "default: 3%" },
+      { name: "Total Invoice Value (\u20b9)", required: false, example: "637221.66", note: "auto-computed if blank" },
+      // Hidden / auto-computed \u2014 kept here so the parser still finds them if present
+      // CGST / SGST / IGST / Taxable Value are NOT shown in the UI list anymore;
+      // the parser computes them from the GST rate when they're missing.
     ],
     showBusiness: true,
     icon: Receipt,
@@ -775,22 +776,43 @@ export default function ImportPage({ type }: ImportPageProps) {
               <h2 className="text-[11px] font-display font-semibold text-muted-foreground uppercase tracking-wider">CSV Format</h2>
             </div>
 
+            {/* Required fields */}
             <div className="space-y-2">
-              {config.columns.map((col, i) => (
-                <div key={col.name} className="flex items-center gap-3 p-2.5 rounded-lg border border-border/30 hover:bg-secondary/10 transition-colors">
-                  <span className="w-6 h-6 rounded-lg bg-secondary/50 flex items-center justify-center text-[10px] font-bold text-muted-foreground shrink-0">
+              <p className="text-[10px] font-semibold uppercase tracking-wider text-foreground/80 mb-1">Required</p>
+              {config.columns.filter((c) => c.required).map((col, i) => (
+                <div key={col.name} className="flex items-center gap-3 p-2.5 rounded-lg border border-primary/20 bg-primary/5">
+                  <span className="w-6 h-6 rounded-lg bg-primary/15 flex items-center justify-center text-[10px] font-bold text-primary shrink-0">
                     {i + 1}
                   </span>
                   <div className="flex-1 min-w-0">
-                    <p className={cn("text-[12px] font-semibold", col.required ? "text-foreground" : "text-muted-foreground")}>
-                      {col.name}
-                      {col.required && <span className="text-destructive ml-0.5">*</span>}
+                    <p className="text-[12px] font-semibold text-foreground">
+                      {col.name}<span className="text-destructive ml-0.5">*</span>
                     </p>
-                    <p className="text-[10px] text-muted-foreground font-mono truncate">{col.example}</p>
+                    <p className="text-[10px] text-muted-foreground font-mono truncate">
+                      {col.example}{(col as any).note ? ` · ${(col as any).note}` : ""}
+                    </p>
                   </div>
                 </div>
               ))}
             </div>
+
+            {/* Optional fields with defaults */}
+            {config.columns.some((c) => !c.required) && (
+              <div className="space-y-2 mt-3 pt-3 border-t border-border/30">
+                <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground mb-1">Optional · sensible defaults applied</p>
+                {config.columns.filter((c) => !c.required).map((col) => (
+                  <div key={col.name} className="flex items-start gap-2 px-2.5 py-1.5">
+                    <span className="w-1 h-1 rounded-full bg-muted-foreground mt-2 shrink-0" />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-[11px] text-muted-foreground">
+                        <span className="font-medium text-foreground/80">{col.name}</span>
+                        {(col as any).note ? <span className="font-mono"> · {(col as any).note}</span> : ""}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
 
             <div className="flex gap-2">
               <button onClick={handleSampleDownload} className="premium-btn-outline flex-1 text-[12px] h-10">

--- a/sweet-rebuild-suite-main/src/pages/ImportPage.tsx
+++ b/sweet-rebuild-suite-main/src/pages/ImportPage.tsx
@@ -16,6 +16,7 @@ import { parseInvoiceExcel, toImportReadyInvoices } from "@/utils/parseInvoiceEx
 import type { ImportReadyInvoice } from "@/utils/parseInvoiceExcel";
 import { indianStates } from "@/utils/mockData";
 import { downloadSampleExcel } from "@/utils/generateSampleExcel";
+import { formatApiError, errorTag } from "@/utils/apiError";
 
 interface ImportPageProps { type: "customer" | "product" | "invoice" | "business" }
 
@@ -186,14 +187,7 @@ function InlineQuickAddCustomer({
       toast({ title: "Customer Created", description: form.name });
       onCreated(created as Customer);
     } catch (err: any) {
-      const detail = err?.response?.data;
-      let errorMsg = "Could not create customer.";
-      if (detail && typeof detail === "object") {
-        errorMsg = Object.entries(detail)
-          .map(([key, val]) => `${key}: ${Array.isArray(val) ? val.join(", ") : val}`)
-          .join("; ");
-      }
-      toast({ title: "Creation Failed", description: errorMsg, variant: "destructive" });
+      toast({ title: `Creation Failed ${errorTag(err)}`, description: formatApiError(err, "Could not create customer."), variant: "destructive", duration: 12000 });
     }
     setSubmitting(false);
   };
@@ -668,15 +662,8 @@ export default function ImportPage({ type }: ImportPageProps) {
         toast({ title: "Import Successful", description: `Records from ${file.name} imported successfully.` });
       }
     } catch (err: any) {
-      const data = err?.response?.data;
-      let msg = "Import failed. Check your file format.";
-      if (data?.error) msg = data.error;
-      else if (data?.detail) msg = data.detail;
-      else if (data?.message) msg = data.message;
-      else if (typeof data === "string") msg = data;
-      else if (err?.message) msg = err.message;
-      logger.error("Import error:", err?.response?.status, data);
-      toast({ title: "Import Failed", description: msg, variant: "destructive" });
+      logger.error("Import error:", err?.response?.status, err?.response?.data);
+      toast({ title: `Import Failed ${errorTag(err)}`, description: formatApiError(err, "Import failed. Check your file format."), variant: "destructive", duration: 15000 });
     }
     setImporting(false);
   };

--- a/sweet-rebuild-suite-main/src/pages/ImportPage.tsx
+++ b/sweet-rebuild-suite-main/src/pages/ImportPage.tsx
@@ -896,7 +896,7 @@ export default function ImportPage({ type }: ImportPageProps) {
                 <label className="text-[12px] font-semibold text-foreground uppercase tracking-wider">Target Business</label>
               </div>
               <select value={bizFilter} onChange={(e) => setBizFilter(e.target.value)} className="premium-select w-full">
-                <option value="all">Auto-detect from Excel (Match by GSTIN)</option>
+                <option value="all">Auto-detect (match GSTIN)</option>
                 {businesses.map((b) => <option key={b.id} value={b.id}>{b.name} — {b.gst_number}</option>)}
               </select>
             </div>

--- a/sweet-rebuild-suite-main/src/pages/ImportPage.tsx
+++ b/sweet-rebuild-suite-main/src/pages/ImportPage.tsx
@@ -64,7 +64,7 @@ const configs = {
       { name: "Bill No.", required: true, example: "100", note: "" },
       { name: "Invoice Date", required: true, example: "06-02-2026", note: "DD-MM-YYYY" },
       { name: "Party Name", required: true, example: "Rajesh Kumar", note: "" },
-      { name: "GST Number", required: true, example: "08AABCK5461H1ZO", note: "blank cell allowed (= unregistered)" },
+      { name: "GST Number", required: false, example: "08AABCK5461H1ZO", note: "blank cell allowed (= unregistered)" },
       { name: "Commodity", required: true, example: "Gold Ornaments", note: "must match a product in your Product list" },
       { name: "Qty (gm)", required: true, example: "37.740", note: "" },
       { name: "Rate (\u20b9/gm)", required: true, example: "16397.00", note: "" },

--- a/sweet-rebuild-suite-main/src/pages/ImportPage.tsx
+++ b/sweet-rebuild-suite-main/src/pages/ImportPage.tsx
@@ -6,7 +6,7 @@ import {
   UserPlus, X, Plus, AlertCircle, Check, Copy, Pencil, Save,
 } from "lucide-react";
 import { useState, useEffect, useMemo } from "react";
-import { useBusinesses, useCustomers, useInvoices } from "@/hooks/useDataStore";
+import { useBusinesses, useCustomers, useInvoices, useProducts } from "@/hooks/useDataStore";
 import type { Business, Customer } from "@/hooks/useDataStore";
 import Breadcrumbs from "@/components/Breadcrumbs";
 import { motion, AnimatePresence } from "framer-motion";
@@ -389,6 +389,8 @@ export default function ImportPage({ type }: ImportPageProps) {
   const { items: businesses } = useBusinesses();
   const { items: customers, refetch: refetchCustomers } = useCustomers();
   const { items: existingInvoices, refetch: refetchInvoices } = useInvoices(undefined, type === "invoice");
+  // Products fetched only when generating the import template (invoice flow)
+  const { items: productsForTemplate } = useProducts(undefined, undefined, type === "invoice");
   const [dragOver, setDragOver] = useState(false);
   const [file, setFile] = useState<File | null>(null);
   const [bizFilter, setBizFilter] = useState("all");
@@ -816,16 +818,43 @@ export default function ImportPage({ type }: ImportPageProps) {
               </div>
             )}
 
-            <div className="flex gap-2">
-              <button onClick={handleSampleDownload} className="premium-btn-outline flex-1 text-[12px] h-10">
+            {type === "invoice" ? (
+              <div className="space-y-2">
+                <button
+                  onClick={() => {
+                    downloadSampleExcel({
+                      businesses: businesses.map((b: any) => ({ name: b.name, gst_number: b.gst_number })),
+                      products: (productsForTemplate || []).map((p: any) => ({ name: p.name })),
+                      includeInward: false,
+                      withSamples: true,
+                    });
+                    toast({ title: "Smart Template Downloaded", description: `Pre-filled with your ${businesses.length} business(es) and ${(productsForTemplate || []).length} product(s)` });
+                  }}
+                  className="premium-btn-primary w-full text-[12px] h-10"
+                >
+                  <FileSpreadsheet className="w-3.5 h-3.5" /> Download Smart Template
+                </button>
+                <button
+                  onClick={() => {
+                    downloadSampleExcel({
+                      businesses: businesses.map((b: any) => ({ name: b.name, gst_number: b.gst_number })),
+                      products: (productsForTemplate || []).map((p: any) => ({ name: p.name })),
+                      includeInward: true,
+                      withSamples: true,
+                    });
+                    toast({ title: "Full Template Downloaded", description: "Includes both Outward + Inward sheets per business" });
+                  }}
+                  className="premium-btn-outline w-full text-[11px] h-9"
+                >
+                  <Download className="w-3.5 h-3.5" /> + Inward sheets too
+                </button>
+                <p className="text-[10px] text-muted-foreground text-center">Pre-filled with your real businesses, GSTINs, and product list dropdowns.</p>
+              </div>
+            ) : (
+              <button onClick={handleSampleDownload} className="premium-btn-outline w-full text-[12px] h-10">
                 <Download className="w-3.5 h-3.5" /> Sample CSV
               </button>
-              {type === "invoice" && (
-                <button onClick={() => { downloadSampleExcel(); toast({ title: "Template Downloaded", description: "invoice-import-template.xlsx" }); }} className="premium-btn-outline flex-1 text-[12px] h-10">
-                  <FileSpreadsheet className="w-3.5 h-3.5" /> Excel Template
-                </button>
-              )}
-            </div>
+            )}
           </div>
 
           {/* Tips */}

--- a/sweet-rebuild-suite-main/src/pages/ImportPage.tsx
+++ b/sweet-rebuild-suite-main/src/pages/ImportPage.tsx
@@ -572,9 +572,17 @@ export default function ImportPage({ type }: ImportPageProps) {
         try {
           const data = e.target?.result as ArrayBuffer;
           const result = parseInvoiceExcel(data);
+          // mapDjangoProduct in useDataStore renames the API fields to
+          // `hsn` (string) and `gstRate` (percentage form, e.g. 3 = 3%).
+          // toImportReadyInvoices accepts either name shape, but passing the
+          // raw camelCase fields here keeps things explicit.
           const invoices = toImportReadyInvoices(
             result,
-            (productsForTemplate || []).map((p: any) => ({ name: p.name, hsn_code: p.hsn_code, gst_tax_rate: p.gst_tax_rate })),
+            (productsForTemplate || []).map((p: any) => ({
+              name: p.name,
+              hsn: p.hsn,
+              gstRate: p.gstRate,
+            })),
           );
           if (invoices.length > 0) {
             toast({ title: "Excel Parsed", description: `Found ${invoices.length} invoices from ${result.firms.length} firm(s)` });

--- a/sweet-rebuild-suite-main/src/pages/ImportPreview.tsx
+++ b/sweet-rebuild-suite-main/src/pages/ImportPreview.tsx
@@ -173,7 +173,7 @@ export default function ImportPreview() {
                 <th className="px-3 py-2.5 text-left font-semibold">Commodity</th>
                 <th className="px-3 py-2.5 text-right font-semibold">Qty</th>
                 <th className="px-3 py-2.5 text-right font-semibold">Rate</th>
-                <th className="px-3 py-2.5 text-center font-semibold">GST %</th>
+                <th className="px-3 py-2.5 text-center font-semibold whitespace-nowrap">GST&nbsp;%</th>
                 <th className="px-3 py-2.5 text-right font-semibold">Taxable</th>
                 <th className="px-3 py-2.5 text-right font-semibold">CGST</th>
                 <th className="px-3 py-2.5 text-right font-semibold">SGST</th>

--- a/sweet-rebuild-suite-main/src/pages/ImportPreview.tsx
+++ b/sweet-rebuild-suite-main/src/pages/ImportPreview.tsx
@@ -173,6 +173,7 @@ export default function ImportPreview() {
                 <th className="px-3 py-2.5 text-left font-semibold">Commodity</th>
                 <th className="px-3 py-2.5 text-right font-semibold">Qty</th>
                 <th className="px-3 py-2.5 text-right font-semibold">Rate</th>
+                <th className="px-3 py-2.5 text-center font-semibold">GST %</th>
                 <th className="px-3 py-2.5 text-right font-semibold">Taxable</th>
                 <th className="px-3 py-2.5 text-right font-semibold">CGST</th>
                 <th className="px-3 py-2.5 text-right font-semibold">SGST</th>
@@ -195,6 +196,7 @@ export default function ImportPreview() {
                   <td className="px-3 py-2 text-muted-foreground">{inv.items[0]?.productName || "-"}</td>
                   <td className="px-3 py-2 text-right font-mono">{inv.items.reduce((s, i) => s + i.qty, 0).toFixed(3)}</td>
                   <td className="px-3 py-2 text-right font-mono">{inv.items[0]?.rate?.toFixed(2) || "-"}</td>
+                  <td className="px-3 py-2 text-center font-mono text-muted-foreground">{(inv.items[0]?.gstRate ?? 0)}%</td>
                   <td className="px-3 py-2 text-right font-mono">{fmt(inv.subtotal)}</td>
                   <td className="px-3 py-2 text-right font-mono">{fmt(inv.totalCGST)}</td>
                   <td className="px-3 py-2 text-right font-mono">{fmt(inv.totalSGST)}</td>
@@ -205,7 +207,7 @@ export default function ImportPreview() {
             </tbody>
             <tfoot>
               <tr className="bg-primary/5 border-t-2 border-primary/20 font-semibold">
-                <td colSpan={8} className="px-3 py-2.5 text-right">TOTAL</td>
+                <td colSpan={9} className="px-3 py-2.5 text-right">TOTAL</td>
                 <td className="px-3 py-2.5 text-right font-mono">{fmt(grandTotals.taxable)}</td>
                 <td className="px-3 py-2.5 text-right font-mono">{fmt(grandTotals.cgst)}</td>
                 <td className="px-3 py-2.5 text-right font-mono">{fmt(grandTotals.sgst)}</td>

--- a/sweet-rebuild-suite-main/src/pages/ImportReview.tsx
+++ b/sweet-rebuild-suite-main/src/pages/ImportReview.tsx
@@ -11,6 +11,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { cn } from "@/utils/utils";
 import { useToast } from "@/hooks/use-toast";
 import type { ImportReadyInvoice } from "@/utils/parseInvoiceExcel";
+import { formatApiError, errorTag } from "@/utils/apiError";
 
 interface LocationState {
   parsedInvoices: ImportReadyInvoice[];
@@ -238,18 +239,12 @@ export default function ImportReview() {
         state: { invoices: toImport, result, businessName: businesses.find(b => String(b.id) === bizFilter)?.name || "All Businesses" },
       });
     } catch (err: any) {
-      // Surface real backend errors (DRF validation errors, exceptions) instead of generic "Import failed"
-      const data = err?.response?.data;
-      let msg = err?.message || "Import failed.";
-      if (data) {
-        if (typeof data === "string") msg = data;
-        else if (data.error) msg = data.error;
-        else if (data.detail) msg = data.detail;
-        else if (data.message) msg = data.message;
-        else if (Array.isArray(data.errors)) msg = data.errors.slice(0, 3).join("; ");
-        else msg = JSON.stringify(data).slice(0, 300);
-      }
-      toast({ title: `Import Failed (${err?.response?.status || "network"})`, description: msg, variant: "destructive", duration: 15000 });
+      toast({
+        title: `Import Failed ${errorTag(err)}`,
+        description: formatApiError(err, "Import failed."),
+        variant: "destructive",
+        duration: 15000,
+      });
     }
     setImporting(false);
   };

--- a/sweet-rebuild-suite-main/src/pages/ImportReview.tsx
+++ b/sweet-rebuild-suite-main/src/pages/ImportReview.tsx
@@ -363,6 +363,7 @@ export default function ImportReview() {
                 <th className="px-3 py-2.5 text-right font-semibold text-muted-foreground">Taxable</th>
                 <th className="px-3 py-2.5 text-right font-semibold text-muted-foreground">CGST</th>
                 <th className="px-3 py-2.5 text-right font-semibold text-muted-foreground">SGST</th>
+                <th className="px-3 py-2.5 text-right font-semibold text-muted-foreground">IGST</th>
                 <th className="px-3 py-2.5 text-right font-semibold text-muted-foreground">Total</th>
                 <th className="px-3 py-2.5 w-10"></th>
               </tr>
@@ -422,8 +423,9 @@ export default function ImportReview() {
                       )}
                     </td>
                     <td className="px-3 py-2 text-right tabular-nums">{"\u20b9"}{fmt(inv.subtotal)}</td>
-                    <td className="px-3 py-2 text-right tabular-nums">{"\u20b9"}{fmt(inv.totalCGST)}</td>
-                    <td className="px-3 py-2 text-right tabular-nums">{"\u20b9"}{fmt(inv.totalSGST)}</td>
+                    <td className={cn("px-3 py-2 text-right tabular-nums", inv.totalCGST === 0 && "text-muted-foreground/50")}>{"\u20b9"}{fmt(inv.totalCGST)}</td>
+                    <td className={cn("px-3 py-2 text-right tabular-nums", inv.totalSGST === 0 && "text-muted-foreground/50")}>{"\u20b9"}{fmt(inv.totalSGST)}</td>
+                    <td className={cn("px-3 py-2 text-right tabular-nums", inv.totalIGST === 0 && "text-muted-foreground/50")}>{"\u20b9"}{fmt(inv.totalIGST)}</td>
                     <td className="px-3 py-2 text-right font-semibold tabular-nums">{"\u20b9"}{fmt(inv.total)}</td>
                     <td className="px-3 py-2 text-center">
                       {editingIdx === idx ? (
@@ -447,6 +449,7 @@ export default function ImportReview() {
                 <td className="px-3 py-2.5 text-right tabular-nums">{"\u20b9"}{fmt(selectedResults.reduce((s, v) => s + v.invoice.subtotal, 0))}</td>
                 <td className="px-3 py-2.5 text-right tabular-nums">{"\u20b9"}{fmt(selectedResults.reduce((s, v) => s + v.invoice.totalCGST, 0))}</td>
                 <td className="px-3 py-2.5 text-right tabular-nums">{"\u20b9"}{fmt(selectedResults.reduce((s, v) => s + v.invoice.totalSGST, 0))}</td>
+                <td className="px-3 py-2.5 text-right tabular-nums">{"\u20b9"}{fmt(selectedResults.reduce((s, v) => s + v.invoice.totalIGST, 0))}</td>
                 <td className="px-3 py-2.5 text-right tabular-nums font-bold">{"\u20b9"}{fmt(selectedResults.reduce((s, v) => s + v.invoice.total, 0))}</td>
                 <td></td>
               </tr>

--- a/sweet-rebuild-suite-main/src/pages/ImportReview.tsx
+++ b/sweet-rebuild-suite-main/src/pages/ImportReview.tsx
@@ -211,21 +211,42 @@ export default function ImportReview() {
       }
 
       const { default: api } = await import("@/utils/api");
-      const res = await api.post("invoices/bulk-import/", {
+      const res = await api.post<{ created: number; skipped: number; errors?: string[]; message?: string }>("invoices/bulk-import/", {
         invoices: toImport,
         business_id: bizFilter !== "all" ? bizFilter : undefined,
       });
       const result = res.data;
-      toast({ title: "Import Complete", description: `${result.created} imported, ${result.skipped} skipped.` });
+      const errCount = result.errors?.length || 0;
+      // Show actual outcomes — successes AND failures, with details
+      if (errCount > 0) {
+        const sample = result.errors!.slice(0, 3).join("\n• ");
+        toast({
+          title: `Imported ${result.created}, ${errCount} failed`,
+          description: `• ${sample}${errCount > 3 ? `\n... and ${errCount - 3} more (see Audit Log)` : ""}`,
+          variant: errCount === toImport.length ? "destructive" : "default",
+          duration: 12000,
+        });
+      } else {
+        toast({ title: "Import Complete", description: `${result.created} imported, ${result.skipped} skipped.` });
+      }
       refetchInvoices();
       refetchCustomers();
-      // Navigate to post-import summary
       navigate("/billing/import/preview", {
         state: { invoices: toImport, result, businessName: businesses.find(b => String(b.id) === bizFilter)?.name || "All Businesses" },
       });
     } catch (err: any) {
-      const msg = err?.response?.data?.error || err?.response?.data?.message || err?.message || "Import failed.";
-      toast({ title: "Import Failed", description: msg, variant: "destructive" });
+      // Surface real backend errors (DRF validation errors, exceptions) instead of generic "Import failed"
+      const data = err?.response?.data;
+      let msg = err?.message || "Import failed.";
+      if (data) {
+        if (typeof data === "string") msg = data;
+        else if (data.error) msg = data.error;
+        else if (data.detail) msg = data.detail;
+        else if (data.message) msg = data.message;
+        else if (Array.isArray(data.errors)) msg = data.errors.slice(0, 3).join("; ");
+        else msg = JSON.stringify(data).slice(0, 300);
+      }
+      toast({ title: `Import Failed (${err?.response?.status || "network"})`, description: msg, variant: "destructive", duration: 15000 });
     }
     setImporting(false);
   };

--- a/sweet-rebuild-suite-main/src/pages/ImportReview.tsx
+++ b/sweet-rebuild-suite-main/src/pages/ImportReview.tsx
@@ -363,6 +363,7 @@ export default function ImportReview() {
                 <th className="px-3 py-2.5 text-left font-semibold text-muted-foreground">GST</th>
                 <th className="px-3 py-2.5 text-left font-semibold text-muted-foreground">Firm</th>
                 <th className="px-3 py-2.5 text-center font-semibold text-muted-foreground">Items</th>
+                <th className="px-3 py-2.5 text-center font-semibold text-muted-foreground">GST %</th>
                 <th className="px-3 py-2.5 text-right font-semibold text-muted-foreground">Taxable</th>
                 <th className="px-3 py-2.5 text-right font-semibold text-muted-foreground">CGST</th>
                 <th className="px-3 py-2.5 text-right font-semibold text-muted-foreground">SGST</th>
@@ -425,6 +426,13 @@ export default function ImportReview() {
                         <>{inv.items.length}<span className="text-[9px] text-muted-foreground ml-0.5">({inv.items.map(i => `${i.qty}${i.unit || "gms"}`).join(", ")})</span></>
                       )}
                     </td>
+                    <td className="px-3 py-2 text-center font-mono text-muted-foreground text-[11px]">
+                      {(() => {
+                        const rates = Array.from(new Set(inv.items.map(i => i.gstRate))).filter(r => r > 0);
+                        if (rates.length === 0) return <span className="text-destructive/70">?</span>;
+                        return rates.length === 1 ? `${rates[0]}%` : rates.map(r => `${r}%`).join("/");
+                      })()}
+                    </td>
                     <td className="px-3 py-2 text-right tabular-nums">{"\u20b9"}{fmt(inv.subtotal)}</td>
                     <td className={cn("px-3 py-2 text-right tabular-nums", inv.totalCGST === 0 && "text-muted-foreground/50")}>{"\u20b9"}{fmt(inv.totalCGST)}</td>
                     <td className={cn("px-3 py-2 text-right tabular-nums", inv.totalSGST === 0 && "text-muted-foreground/50")}>{"\u20b9"}{fmt(inv.totalSGST)}</td>
@@ -446,7 +454,7 @@ export default function ImportReview() {
             </tbody>
             <tfoot className="bg-secondary/40 border-t-2 border-border/40">
               <tr className="font-semibold text-[11px]">
-                <td colSpan={8} className="px-3 py-2.5 text-right text-muted-foreground uppercase">
+                <td colSpan={9} className="px-3 py-2.5 text-right text-muted-foreground uppercase">
                   Selected Total ({selectedInvoices.size} invoices)
                 </td>
                 <td className="px-3 py-2.5 text-right tabular-nums">{"\u20b9"}{fmt(selectedResults.reduce((s, v) => s + v.invoice.subtotal, 0))}</td>

--- a/sweet-rebuild-suite-main/src/pages/ImportReview.tsx
+++ b/sweet-rebuild-suite-main/src/pages/ImportReview.tsx
@@ -363,7 +363,7 @@ export default function ImportReview() {
                 <th className="px-3 py-2.5 text-left font-semibold text-muted-foreground">GST</th>
                 <th className="px-3 py-2.5 text-left font-semibold text-muted-foreground">Firm</th>
                 <th className="px-3 py-2.5 text-center font-semibold text-muted-foreground">Items</th>
-                <th className="px-3 py-2.5 text-center font-semibold text-muted-foreground">GST %</th>
+                <th className="px-3 py-2.5 text-center font-semibold text-muted-foreground whitespace-nowrap">GST&nbsp;%</th>
                 <th className="px-3 py-2.5 text-right font-semibold text-muted-foreground">Taxable</th>
                 <th className="px-3 py-2.5 text-right font-semibold text-muted-foreground">CGST</th>
                 <th className="px-3 py-2.5 text-right font-semibold text-muted-foreground">SGST</th>

--- a/sweet-rebuild-suite-main/src/pages/ImportReview.tsx
+++ b/sweet-rebuild-suite-main/src/pages/ImportReview.tsx
@@ -98,11 +98,14 @@ export default function ImportReview() {
         customerMatch = customerNameMap.get(inv.customerGST.toLowerCase().trim()) || null;
       }
 
-      // Duplicate check
+      // Duplicate check — must match on business + bill# + date AND TYPE.
+      // Sales invoice #1 (outward) and purchase bill #1 (inward) are
+      // different documents, even when number/date/firm coincide.
       const isDuplicate = existingInvoices.some(
         ei => ei.invoiceNumber === inv.invoiceNumber &&
           String(ei.businessId) === String(businessMatch?.id) &&
-          ei.invoice_date === inv.invoice_date
+          ei.invoice_date === inv.invoice_date &&
+          (ei.type || "OUTWARD").toUpperCase() === inv.type
       );
 
       let status: ValidationResult["status"] = "ready";

--- a/sweet-rebuild-suite-main/src/pages/InvoiceDetail.tsx
+++ b/sweet-rebuild-suite-main/src/pages/InvoiceDetail.tsx
@@ -11,7 +11,7 @@ import {
   FileText, Share2, Download, MessageCircle, Truck, AlertTriangle,
 } from "lucide-react";
 import EwayBillForm from "@/components/EwayBillForm";
-import { cn } from "@/utils/utils";
+import { cn, pluralize } from "@/utils/utils";
 import { useToast } from "@/hooks/use-toast";
 import { motion } from "framer-motion";
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
@@ -46,7 +46,7 @@ export default function InvoiceDetail() {
     { label: "Subtotal", value: formatCurrency(inv.subtotal), icon: Package, color: "text-foreground" },
     { label: "Total Tax", value: formatCurrency(inv.totalTax), icon: Receipt, color: "text-chart-3" },
     { label: "Grand Total", value: formatCurrency(inv.total), icon: IndianRupee, color: "text-primary" },
-    { label: "Items", value: `${inv.items.length} products`, icon: TrendingUp, color: "text-success" },
+    { label: "Items", value: pluralize(inv.items.length, "product"), icon: TrendingUp, color: "text-success" },
   ];
 
   return (
@@ -122,10 +122,10 @@ export default function InvoiceDetail() {
                 <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">From</p>
               </div>
               <p className="text-[14px] font-display font-bold text-foreground">{inv.businessName}</p>
-              {biz && (
+              {biz && (biz.gst_number || biz.address) && (
                 <div className="space-y-1 text-[12px] text-muted-foreground">
-                  <p className="flex items-center gap-1.5"><Hash className="w-3 h-3" /><span className="font-mono">{biz.gst_number}</span></p>
-                  <p className="flex items-center gap-1.5"><MapPin className="w-3 h-3" />{biz.address}</p>
+                  {biz.gst_number && <p className="flex items-center gap-1.5"><Hash className="w-3 h-3" /><span className="font-mono">{biz.gst_number}</span></p>}
+                  {biz.address && <p className="flex items-center gap-1.5"><MapPin className="w-3 h-3" />{biz.address}</p>}
                 </div>
               )}
             </div>
@@ -135,10 +135,10 @@ export default function InvoiceDetail() {
                 <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">To</p>
               </div>
               <Link to={`/billing/customer/${inv.customerId}`} className="text-[14px] font-display font-bold text-primary hover:underline">{inv.customerName}</Link>
-              {customer && (
+              {customer && (customer.gst_number || customer.address) && (
                 <div className="space-y-1 text-[12px] text-muted-foreground">
-                  <p className="flex items-center gap-1.5"><Hash className="w-3 h-3" /><span className="font-mono">{customer.gst_number}</span></p>
-                  <p className="flex items-center gap-1.5"><MapPin className="w-3 h-3" />{customer.address}</p>
+                  {customer.gst_number && <p className="flex items-center gap-1.5"><Hash className="w-3 h-3" /><span className="font-mono">{customer.gst_number}</span></p>}
+                  {customer.address && <p className="flex items-center gap-1.5"><MapPin className="w-3 h-3" />{customer.address}</p>}
                 </div>
               )}
             </div>
@@ -248,7 +248,7 @@ export default function InvoiceDetail() {
                   { label: "Financial Year", value: inv.financialYear },
                   { label: "Type", value: inv.type },
                   { label: "GST Type", value: inv.isIGST ? "IGST (Interstate)" : "CGST/SGST (Intrastate)" },
-                  { label: "Items", value: `${inv.items.length} line items` },
+                  { label: "Items", value: pluralize(inv.items.length, "line item") },
                   { label: "Created", value: formatDate(inv.createdAt) },
                 ].map((d) => (
                   <div key={d.label} className="flex justify-between"><span className="text-muted-foreground">{d.label}</span><span className="text-foreground font-medium">{d.value}</span></div>

--- a/sweet-rebuild-suite-main/src/pages/InvoiceForm.tsx
+++ b/sweet-rebuild-suite-main/src/pages/InvoiceForm.tsx
@@ -92,7 +92,7 @@ export default function InvoiceForm({ mode }: InvoiceFormProps) {
           date: inv.invoice_date || new Date().toISOString().split("T")[0],
           type: (inv.type_of_invoice || "OUTWARD").toUpperCase(),
           isIGST: inv.is_igst_applicable || false,
-          financialYear: inv.financial_year || "2024-25",
+          financialYear: inv.financial_year || currentFY,
         });
 
         // Store fallback names for dropdown rendering

--- a/sweet-rebuild-suite-main/src/pages/InvoiceForm.tsx
+++ b/sweet-rebuild-suite-main/src/pages/InvoiceForm.tsx
@@ -19,6 +19,7 @@ import SearchableSelect from "@/components/SearchableSelect";
 import QuickProductModal from "@/components/QuickProductModal";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useMobileMode } from "@/contexts/MobileModeContext";
+import { formatApiError, errorTag } from "@/utils/apiError";
 
 interface InvoiceFormProps { mode: "create" | "edit" }
 
@@ -372,8 +373,7 @@ export default function InvoiceForm({ mode }: InvoiceFormProps) {
           navigate("/billing/invoice/list");
         }
       } catch (err: any) {
-        const msg = err?.response?.data?.detail || err?.response?.data?.error || err?.message || "Create failed.";
-        toast({ title: "Create Failed", description: msg, variant: "destructive" });
+        toast({ title: `Create Failed ${errorTag(err)}`, description: formatApiError(err, "Create failed."), variant: "destructive", duration: 12000 });
         setDirty(true);
       }
     } else if (id) {
@@ -399,8 +399,7 @@ export default function InvoiceForm({ mode }: InvoiceFormProps) {
         toast({ title: "Invoice Updated", description: `${form.invoiceNumber} — ${formatCurrency(total)}` });
         navigate("/billing/invoice/list");
       } catch (err: any) {
-        const msg = err?.response?.data?.detail || err?.response?.data?.error || err?.message || "Update failed.";
-        toast({ title: "Update Failed", description: msg, variant: "destructive" });
+        toast({ title: `Update Failed ${errorTag(err)}`, description: formatApiError(err, "Update failed."), variant: "destructive", duration: 12000 });
         setDirty(true);
       }
     }

--- a/sweet-rebuild-suite-main/src/pages/InvoiceList.tsx
+++ b/sweet-rebuild-suite-main/src/pages/InvoiceList.tsx
@@ -13,7 +13,7 @@ import { useInvoices, useBusinesses, useCustomers, useDashboardStats } from "@/h
 import type { InvoiceFilters } from "@/hooks/useDataStore";
 import Breadcrumbs from "@/components/Breadcrumbs";
 
-import { cn } from "@/utils/utils";
+import { cn, pluralize } from "@/utils/utils";
 import { useToast } from "@/hooks/use-toast";
 import DeleteConfirmDialog from "@/components/DeleteConfirmDialog";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -95,7 +95,7 @@ export default function InvoiceList() {
   // ─── MOBILE VIEW ───
   if (isMobile) {
     return (
-      <div className="p-4 space-y-4">
+      <div className="p-4 pb-40 space-y-4">
         <div>
           <h1 className="text-2xl font-display font-bold text-foreground tracking-tight">Invoices</h1>
           <p className="text-xs text-muted-foreground mt-0.5">{totalCount} invoices · FY {fyFilter === "all" ? "All" : fyFilter}</p>
@@ -156,7 +156,7 @@ export default function InvoiceList() {
                 </div>
               </div>
               <div className="flex items-center justify-between pt-2.5 mt-2.5 border-t border-border/30">
-                <span className="text-[11px] text-muted-foreground">{inv.lineItemCount} items · Tax {formatCurrency(inv.totalTax)}</span>
+                <span className="text-[11px] text-muted-foreground">{pluralize(inv.lineItemCount, "item")} · Tax {formatCurrency(inv.totalTax)}</span>
                 <div className="flex items-center gap-2">
                   <button
                     onClick={(e) => { e.preventDefault(); e.stopPropagation(); shareInvoice(inv); }}

--- a/sweet-rebuild-suite-main/src/pages/InvoicePrintTally.tsx
+++ b/sweet-rebuild-suite-main/src/pages/InvoicePrintTally.tsx
@@ -166,14 +166,14 @@ export default function InvoicePrintTally() {
             if (!url) {
               return (
                 <div className="flex flex-col items-center justify-center py-16 px-6 text-center gap-4">
-                  <p className="text-sm text-muted-foreground">Could not generate preview. Use the Download button above.</p>
+                  <p className="text-sm text-muted-foreground">Could not generate preview. Use the PDF button above.</p>
                 </div>
               );
             }
             if (isMobile) {
               return (
                 <div className="flex flex-col items-center justify-center py-16 px-6 text-center gap-4">
-                  <p className="text-sm text-muted-foreground">PDF preview is not available on mobile. Use the Download button above to get the PDF.</p>
+                  <p className="text-sm text-muted-foreground">PDF preview is not available on mobile. Tap the PDF button above to download it.</p>
                 </div>
               );
             }

--- a/sweet-rebuild-suite-main/src/pages/ProductList.tsx
+++ b/sweet-rebuild-suite-main/src/pages/ProductList.tsx
@@ -11,7 +11,7 @@ import { motion } from "framer-motion";
 import { formatCurrency } from "@/utils/mockData";
 import { useProducts, useInvoices } from "@/hooks/useDataStore";
 import Breadcrumbs from "@/components/Breadcrumbs";
-import { cn } from "@/utils/utils";
+import { cn, pluralize } from "@/utils/utils";
 import { useToast } from "@/hooks/use-toast";
 import DeleteConfirmDialog from "@/components/DeleteConfirmDialog";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -94,10 +94,10 @@ export default function ProductList() {
   // ─── MOBILE VIEW ───
   if (isMobile) {
     return (
-      <div className="p-4 space-y-4">
+      <div className="p-4 pb-40 space-y-4">
         <div>
           <h1 className="text-2xl font-display font-bold text-foreground tracking-tight">Products</h1>
-          <p className="text-xs text-muted-foreground mt-0.5">{totalProducts} items in catalog</p>
+          <p className="text-xs text-muted-foreground mt-0.5">{pluralize(totalProducts, "item")} in catalog</p>
         </div>
 
         {/* Stats scroll */}
@@ -217,7 +217,7 @@ export default function ProductList() {
           </div>
           <div>
             <h1 className="text-3xl font-display font-bold text-foreground tracking-tight">Products</h1>
-            <p className="text-sm text-muted-foreground mt-0.5">{totalProducts} items in catalog</p>
+            <p className="text-sm text-muted-foreground mt-0.5">{pluralize(totalProducts, "item")} in catalog</p>
           </div>
         </div>
         <div className="flex items-center gap-2.5">

--- a/sweet-rebuild-suite-main/src/pages/Reports.tsx
+++ b/sweet-rebuild-suite-main/src/pages/Reports.tsx
@@ -266,10 +266,16 @@ export default function Reports() {
             <motion.div variants={fadeUp} className="elevated-card rounded-2xl p-5">
               <h2 className="text-[13px] font-display font-semibold text-foreground mb-3">Tax Distribution</h2>
               {pieData.length === 0 ? <div className="h-[180px] flex items-center justify-center text-muted-foreground text-sm">No data</div> : (
-                <div className="h-[180px]"><ResponsiveContainer width="100%" height="100%"><RPieChart><Pie data={pieData} cx="50%" cy="50%" innerRadius={40} outerRadius={70} paddingAngle={4} dataKey="value" label={({ name, value }) => `${name}: ${formatCurrency(value)}`}>{pieData.map((_, i) => <Cell key={i} fill={PIE_COLORS[i % PIE_COLORS.length]} />)}</Pie><Tooltip contentStyle={{ background: "hsl(var(--card))", border: "1px solid hsl(var(--border))", borderRadius: 12, fontSize: 12, color: "hsl(var(--foreground))" }} itemStyle={{ color: "hsl(var(--foreground))" }} formatter={(v: number) => formatCurrency(v)} /></RPieChart></ResponsiveContainer></div>
+                <div className="h-[180px]"><ResponsiveContainer width="100%" height="100%"><RPieChart><Pie data={pieData} cx="50%" cy="50%" innerRadius={45} outerRadius={75} paddingAngle={3} dataKey="value">{pieData.map((_, i) => <Cell key={i} fill={PIE_COLORS[i % PIE_COLORS.length]} />)}</Pie><Tooltip contentStyle={{ background: "hsl(var(--card))", border: "1px solid hsl(var(--border))", borderRadius: 12, fontSize: 12, color: "hsl(var(--foreground))" }} itemStyle={{ color: "hsl(var(--foreground))" }} formatter={(v: number) => formatCurrency(v)} /></RPieChart></ResponsiveContainer></div>
               )}
-              <div className="flex items-center justify-center gap-4 mt-2">
-                {pieData.map((d, i) => (<div key={d.name} className="flex items-center gap-1.5"><div className="w-2.5 h-2.5 rounded-full" style={{ background: PIE_COLORS[i] }} /><span className="text-[11px] text-muted-foreground">{d.name}</span></div>))}
+              <div className="flex items-center justify-center gap-4 mt-2 flex-wrap">
+                {pieData.map((d, i) => (
+                  <div key={d.name} className="flex items-center gap-1.5">
+                    <div className="w-2.5 h-2.5 rounded-full shrink-0" style={{ background: PIE_COLORS[i] }} />
+                    <span className="text-[11px] text-muted-foreground">{d.name}</span>
+                    <span className="text-[11px] font-medium text-foreground tabular-nums">{formatCurrency(d.value)}</span>
+                  </div>
+                ))}
               </div>
             </motion.div>
           </motion.div>

--- a/sweet-rebuild-suite-main/src/pages/Reports.tsx
+++ b/sweet-rebuild-suite-main/src/pages/Reports.tsx
@@ -52,6 +52,9 @@ export default function Reports() {
   const totalCount = totals.count;
 
   // Monthly data from server stats
+  // Round to 3 decimal places to avoid floating-point noise (e.g. 6107.1684000000005)
+  // showing in chart tooltips.
+  const r3 = (n: number) => Math.round(n * 1000) / 1000;
   const monthlyData = useMemo(() => {
     const fyStart = parseInt(selectedFY.split("-")[0]);
     return MONTHS.map((m, idx) => {
@@ -60,8 +63,8 @@ export default function Reports() {
       const match = (statsData?.monthly || []).find((d: any) => d.month === monthNum && d.year === year);
       return {
         month: m,
-        sales: match ? (Number(match.outward_total) || 0) / 1000 : 0,
-        purchases: match ? (Number(match.inward_total) || 0) / 1000 : 0,
+        sales: match ? r3((Number(match.outward_total) || 0) / 1000) : 0,
+        purchases: match ? r3((Number(match.inward_total) || 0) / 1000) : 0,
       };
     });
   }, [selectedFY, statsData?.monthly]);
@@ -256,7 +259,11 @@ export default function Reports() {
                   <BarChart data={monthlyData} barGap={2}>
                     <XAxis dataKey="month" tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 10 }} axisLine={false} tickLine={false} />
                     <YAxis tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 10 }} axisLine={false} tickLine={false} width={40} />
-                    <Tooltip contentStyle={{ background: "hsl(var(--card))", border: "1px solid hsl(var(--border))", borderRadius: 12, fontSize: 12 }} />
+                    <Tooltip
+                      contentStyle={{ background: "hsl(var(--card))", border: "1px solid hsl(var(--border))", borderRadius: 12, fontSize: 12, color: "hsl(var(--foreground))" }}
+                      itemStyle={{ color: "hsl(var(--foreground))" }}
+                      formatter={(v: number) => Math.round(v * 1000) / 1000}
+                    />
                     <Bar dataKey="sales" name="Sales" fill="hsl(var(--chart-1))" radius={[6, 6, 0, 0]} />
                     <Bar dataKey="purchases" name="Purchases" fill="hsl(var(--chart-2))" radius={[6, 6, 0, 0]} />
                   </BarChart>

--- a/sweet-rebuild-suite-main/src/pages/Reports.tsx
+++ b/sweet-rebuild-suite-main/src/pages/Reports.tsx
@@ -257,7 +257,7 @@ export default function Reports() {
               <div className={cn(isMobile ? "h-[180px]" : "h-[260px]")}>
                 <ResponsiveContainer width="100%" height="100%">
                   <BarChart data={monthlyData} barGap={2}>
-                    <XAxis dataKey="month" tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 10 }} axisLine={false} tickLine={false} />
+                    <XAxis dataKey="month" tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 10 }} axisLine={false} tickLine={false} interval={0} tickFormatter={isMobile ? (v: string) => v.slice(0, 1) : undefined} />
                     <YAxis tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 10 }} axisLine={false} tickLine={false} width={40} />
                     <Tooltip
                       contentStyle={{ background: "hsl(var(--card))", border: "1px solid hsl(var(--border))", borderRadius: 12, fontSize: 12, color: "hsl(var(--foreground))" }}

--- a/sweet-rebuild-suite-main/src/pages/Settings.tsx
+++ b/sweet-rebuild-suite-main/src/pages/Settings.tsx
@@ -57,6 +57,15 @@ export default function Settings() {
   const [settings, setSettings] = useState(() => loadSettings(businesses[0]?.id || ""));
   const [nextInvoiceInfo, setNextInvoiceInfo] = useState<string>("");
 
+  // useState initializer runs before businesses load (async fetch), so
+  // defaultBusinessId starts empty and stays empty even after the dropdown
+  // visually shows the first business. Sync state once businesses arrive.
+  useEffect(() => {
+    if (!settings.defaultBusinessId && businesses.length > 0) {
+      setSettings((p) => ({ ...p, defaultBusinessId: String(businesses[0].id) }));
+    }
+  }, [businesses, settings.defaultBusinessId]);
+
   // Fetch real next invoice number when business changes
   useEffect(() => {
     if (!settings.defaultBusinessId) return;

--- a/sweet-rebuild-suite-main/src/pages/UserManagement.tsx
+++ b/sweet-rebuild-suite-main/src/pages/UserManagement.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/utils/utils";
 import { useToast } from "@/hooks/use-toast";
 import { usePermission } from "@/hooks/usePermission";
 import api from "@/utils/api";
+import { formatApiError, errorTag } from "@/utils/apiError";
 
 interface UserData {
   id: number;
@@ -69,7 +70,7 @@ export default function UserManagement() {
       setCreateForm({ username: "", password: "", email: "", first_name: "", last_name: "", role: "editor" });
       fetchUsers();
     } catch (err: any) {
-      toast({ title: "Failed", description: err?.response?.data?.error || "Could not create user.", variant: "destructive" });
+      toast({ title: `Failed ${errorTag(err)}`, description: formatApiError(err, "Could not create user."), variant: "destructive", duration: 12000 });
     }
     setCreating(false);
   };
@@ -81,7 +82,7 @@ export default function UserManagement() {
       fetchUsers();
       setEditingId(null);
     } catch (err: any) {
-      toast({ title: "Failed", description: err?.response?.data?.error || "Could not update role.", variant: "destructive" });
+      toast({ title: `Failed ${errorTag(err)}`, description: formatApiError(err, "Could not update role."), variant: "destructive", duration: 12000 });
     }
   };
 

--- a/sweet-rebuild-suite-main/src/pages/UserManagement.tsx
+++ b/sweet-rebuild-suite-main/src/pages/UserManagement.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { Users, Plus, Shield, Pencil, UserCheck, UserX, Loader2 } from "lucide-react";
 import Breadcrumbs from "@/components/Breadcrumbs";
 import { motion } from "framer-motion";
-import { cn } from "@/utils/utils";
+import { cn, pluralize } from "@/utils/utils";
 import { useToast } from "@/hooks/use-toast";
 import { usePermission } from "@/hooks/usePermission";
 import api from "@/utils/api";
@@ -105,7 +105,7 @@ export default function UserManagement() {
           </div>
           <div>
             <h1 className="text-2xl font-display font-bold text-foreground tracking-tight">User Management</h1>
-            <p className="text-sm text-muted-foreground">{users.length} users</p>
+            <p className="text-sm text-muted-foreground">{pluralize(users.length, "user")}</p>
           </div>
         </div>
         <button onClick={() => setShowCreate(!showCreate)} className="premium-btn-primary text-[13px]">

--- a/sweet-rebuild-suite-main/src/pages/UserManagement.tsx
+++ b/sweet-rebuild-suite-main/src/pages/UserManagement.tsx
@@ -143,7 +143,8 @@ export default function UserManagement() {
         {loading ? (
           <div className="p-12 text-center"><Loader2 className="w-6 h-6 animate-spin mx-auto text-muted-foreground" /></div>
         ) : (
-          <table className="table-premium text-[13px]">
+          <div className="overflow-x-auto -mx-px">
+          <table className="table-premium text-[13px] min-w-[640px]">
             <thead><tr><th>User</th><th>Email</th><th>Role</th><th>Status</th><th>Last Login</th><th>Actions</th></tr></thead>
             <tbody>
               {users.map((u) => {
@@ -197,6 +198,7 @@ export default function UserManagement() {
               })}
             </tbody>
           </table>
+          </div>
         )}
       </div>
 

--- a/sweet-rebuild-suite-main/src/utils/apiError.ts
+++ b/sweet-rebuild-suite-main/src/utils/apiError.ts
@@ -16,7 +16,24 @@ export function formatApiError(err: any, fallback = "Something went wrong"): str
     return err.message || fallback;
   }
   const { status, data } = err.response;
-  if (typeof data === "string") return `[${status}] ${data}`;
+  if (typeof data === "string") {
+    // Detect Django debug HTML / generic HTML and pull out the actual exception
+    if (data.startsWith("<!DOCTYPE") || data.includes("<html") || data.includes("<pre class=\"exception_value\"")) {
+      // Try Django's <pre class="exception_value">...
+      const m = data.match(/<pre[^>]*class="exception_value"[^>]*>([\s\S]*?)<\/pre>/i);
+      if (m) {
+        const text = m[1].replace(/<[^>]+>/g, "").replace(/&[a-z#0-9]+;/gi, " ").trim();
+        return `[${status}] ${text.slice(0, 300)}`;
+      }
+      // Try <title>
+      const t = data.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+      if (t) {
+        return `[${status}] Server error — ${t[1].replace(/\s+/g, " ").trim().slice(0, 200)}`;
+      }
+      return `[${status}] Server returned an HTML error page. Check the server logs.`;
+    }
+    return `[${status}] ${data.slice(0, 400)}`;
+  }
   if (!data || typeof data !== "object") return `[${status}] ${err.message || fallback}`;
 
   // DRF detail

--- a/sweet-rebuild-suite-main/src/utils/apiError.ts
+++ b/sweet-rebuild-suite-main/src/utils/apiError.ts
@@ -1,0 +1,54 @@
+/**
+ * Format an error from an `api.*` call (axios) into a human-readable message
+ * that surfaces the actual backend response, not generic "Something went wrong".
+ *
+ * Handles:
+ * - DRF validation errors: { field: ["msg"] }
+ * - DRF detail: { detail: "msg" }
+ * - Custom error: { error: "msg" } / { message: "msg" }
+ * - Plain string body
+ * - Network errors (no response)
+ */
+export function formatApiError(err: any, fallback = "Something went wrong"): string {
+  if (!err) return fallback;
+  // Network error — no response from server
+  if (!err.response) {
+    return err.message || fallback;
+  }
+  const { status, data } = err.response;
+  if (typeof data === "string") return `[${status}] ${data}`;
+  if (!data || typeof data !== "object") return `[${status}] ${err.message || fallback}`;
+
+  // DRF detail
+  if (typeof data.detail === "string") return data.detail;
+  // Custom error / message field
+  if (typeof data.error === "string") return data.error;
+  if (typeof data.message === "string") return data.message;
+  // Array of errors
+  if (Array.isArray(data.errors)) return data.errors.slice(0, 3).map(String).join("; ");
+  // DRF field errors: { field: ["msg1", "msg2"], ... }
+  const fieldErrors: string[] = [];
+  for (const [k, v] of Object.entries(data)) {
+    if (Array.isArray(v)) {
+      fieldErrors.push(`${k}: ${v.join(", ")}`);
+    } else if (typeof v === "string") {
+      fieldErrors.push(`${k}: ${v}`);
+    }
+  }
+  if (fieldErrors.length) return fieldErrors.slice(0, 3).join(" | ");
+  // Last resort — dump JSON
+  try {
+    return JSON.stringify(data).slice(0, 300);
+  } catch {
+    return `[${status}] ${err.message || fallback}`;
+  }
+}
+
+/**
+ * Status code as a short tag, e.g. "(401)" or "(network)".
+ */
+export function errorTag(err: any): string {
+  if (!err) return "";
+  if (!err.response) return "(network)";
+  return `(${err.response.status})`;
+}

--- a/sweet-rebuild-suite-main/src/utils/generateSampleExcel.test.ts
+++ b/sweet-rebuild-suite-main/src/utils/generateSampleExcel.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import * as XLSX from "xlsx-js-style";
+import { generateSampleExcelBytes } from "./generateSampleExcel";
+
+function buildWorkbook(opts: Parameters<typeof generateSampleExcelBytes>[0]) {
+  const bytes = generateSampleExcelBytes(opts);
+  return XLSX.read(bytes, { type: "array" });
+}
+
+function getCellText(ws: XLSX.WorkSheet, addr: string): string {
+  const c = ws[addr];
+  if (!c) return "";
+  return String(c.v ?? "");
+}
+
+describe("generateSampleExcel — smart import template", () => {
+  it("includes an Instructions sheet first", async () => {
+    const wb = buildWorkbook({
+      businesses: [{ name: "LODHA", gst_number: "08AAGPL3375F1ZO" }],
+      products: [{ name: "GOLD" }],
+    });
+    
+    expect(wb.SheetNames[0]).toBe("Instructions");
+  });
+
+  it("creates one Outward sheet per business by default", async () => {
+    const wb = buildWorkbook({
+      businesses: [
+        { name: "ALPHA", gst_number: "08A1" },
+        { name: "BETA", gst_number: "08B2" },
+      ],
+      products: [{ name: "GOLD" }],
+      includeInward: false,
+    });
+    
+    expect(wb.SheetNames).toContain("ALPHA - OUT");
+    expect(wb.SheetNames).toContain("BETA - OUT");
+    expect(wb.SheetNames).not.toContain("ALPHA - IN");
+  });
+
+  it("adds Inward sheets when includeInward: true", async () => {
+    const wb = buildWorkbook({
+      businesses: [{ name: "ALPHA", gst_number: "08A1" }],
+      products: [{ name: "GOLD" }],
+      includeInward: true,
+    });
+    
+    expect(wb.SheetNames).toContain("ALPHA - OUT");
+    expect(wb.SheetNames).toContain("ALPHA - IN");
+  });
+
+  it("pre-fills business name and GSTIN in firm sheets", async () => {
+    const wb = buildWorkbook({
+      businesses: [{ name: "Test Firm", gst_number: "08TESTGSTIN1Z1" }],
+      products: [{ name: "GOLD" }],
+    });
+    
+    const ws = wb.Sheets["Test Firm - OUT"];
+    expect(getCellText(ws, "A1")).toBe("TEST FIRM"); // uppercase title
+    expect(getCellText(ws, "A2")).toContain("08TESTGSTIN1Z1");
+    expect(getCellText(ws, "A3")).toBe("Outward Supply");
+  });
+
+  it("uses real product names in sample rows", async () => {
+    const wb = buildWorkbook({
+      businesses: [{ name: "F1", gst_number: "08X" }],
+      products: [{ name: "GOLD ORNAMENTS" }, { name: "SILVER ORNAMENTS" }],
+      withSamples: true,
+    });
+    
+    const ws = wb.Sheets["F1 - OUT"];
+    // Sample data starts at row 7 (index 6) — col F is index 5
+    const sampleCommodity1 = getCellText(ws, "F7");
+    const sampleCommodity2 = getCellText(ws, "F8");
+    expect(sampleCommodity1).toBe("GOLD ORNAMENTS");
+    expect(sampleCommodity2).toBe("SILVER ORNAMENTS");
+  });
+
+  it("falls back gracefully when no businesses/products supplied", async () => {
+    const wb = buildWorkbook({});
+    
+    expect(wb.SheetNames[0]).toBe("Instructions");
+    expect(wb.SheetNames.length).toBeGreaterThan(1); // at least one fallback firm sheet
+  });
+
+  it("template has 8 column headers (7 required + 1 optional Total)", async () => {
+    const wb = buildWorkbook({
+      businesses: [{ name: "F1", gst_number: "08X" }],
+      products: [{ name: "GOLD" }],
+    });
+    
+    const ws = wb.Sheets["F1 - OUT"];
+    // Header row at row 6 (index 5)
+    expect(getCellText(ws, "A6")).toBe("S.No.");
+    expect(getCellText(ws, "B6")).toBe("Bill No.");
+    expect(getCellText(ws, "C6")).toBe("Invoice Date");
+    expect(getCellText(ws, "D6")).toBe("Party Name");
+    expect(getCellText(ws, "E6")).toBe("GST Number");
+    expect(getCellText(ws, "F6")).toBe("Commodity");
+    expect(getCellText(ws, "G6")).toBe("Qty (gm)");
+    expect(getCellText(ws, "H6")).toBe("Rate (₹/gm)");
+    expect(getCellText(ws, "I6")).toContain("Total Invoice Value");
+    // Should NOT have a "GST Rate" or "HSN Code" column in the smart template
+    expect(getCellText(ws, "J6")).toBe("");
+  });
+});

--- a/sweet-rebuild-suite-main/src/utils/generateSampleExcel.ts
+++ b/sweet-rebuild-suite-main/src/utils/generateSampleExcel.ts
@@ -1,63 +1,95 @@
+/**
+ * Smart import template generator.
+ *
+ * Generates a multi-sheet Excel workbook customised to the user's actual
+ * data:
+ *   - One sheet per Business (with the firm's real name + GSTIN pre-filled)
+ *   - Optional separate sheets for Inward and Outward supply
+ *   - Sample rows use the user's actual Product master (not invented names)
+ *   - Current month + financial year baked into the header
+ *   - Data validation dropdowns for Commodity (from Product list)
+ *   - First sheet is "Instructions" — what's required, what's auto-computed
+ *
+ * Replaces the previous static sample with placeholder text.
+ */
 import * as XLSX from "xlsx-js-style";
 
 const DARK_BLUE = "1F3864";
 const LIGHT_BLUE = "DCE6F1";
 const WHITE = "FFFFFF";
 const AMBER = "FFC000";
+const GREY_TEXT = "666666";
+const SUCCESS_GREEN = "4F8C5A";
+
+export interface TemplateBusiness {
+  id?: number | string;
+  name: string;
+  gst_number?: string;
+  gstin?: string;
+}
+export interface TemplateProduct {
+  name: string;
+}
+export interface TemplateOptions {
+  businesses?: TemplateBusiness[];
+  products?: TemplateProduct[];
+  /** Include both Outward + Inward sheets per firm (default: outward only) */
+  includeInward?: boolean;
+  /** Show sample rows in each sheet (default: true) */
+  withSamples?: boolean;
+}
 
 function bdr() {
   const s = { style: "thin", color: { rgb: "B4C6E7" } };
   return { top: s, bottom: s, left: s, right: s };
 }
-
+const titleS = () => ({
+  font: { bold: true, sz: 14, name: "Arial", color: { rgb: WHITE } },
+  fill: { fgColor: { rgb: DARK_BLUE } },
+  alignment: { horizontal: "center" as const, vertical: "center" as const },
+  border: bdr(),
+});
+const subS = () => ({
+  font: { bold: true, sz: 11, name: "Arial", color: { rgb: DARK_BLUE } },
+  fill: { fgColor: { rgb: LIGHT_BLUE } },
+  alignment: { horizontal: "center" as const, vertical: "center" as const },
+  border: bdr(),
+});
+const gstS = () => ({
+  font: { bold: true, sz: 10, name: "Arial", color: { rgb: DARK_BLUE } },
+  fill: { fgColor: { rgb: AMBER } },
+  alignment: { horizontal: "center" as const, vertical: "center" as const },
+  border: bdr(),
+});
 const hdrS = () => ({
   font: { bold: true, sz: 10, name: "Arial", color: { rgb: WHITE } },
   fill: { fgColor: { rgb: DARK_BLUE } },
   alignment: { horizontal: "center" as const, vertical: "center" as const, wrapText: true },
   border: bdr(),
 });
-
-const metaS = () => ({
-  font: { bold: true, sz: 11, name: "Arial", color: { rgb: DARK_BLUE } },
-  fill: { fgColor: { rgb: LIGHT_BLUE } },
-  alignment: { horizontal: "center" as const, vertical: "center" as const },
-  border: bdr(),
+const optHdrS = () => ({
+  ...hdrS(),
+  font: { bold: true, sz: 10, name: "Arial", color: { rgb: WHITE }, italic: true },
+  fill: { fgColor: { rgb: GREY_TEXT } },
 });
-
 const dataS = (even: boolean, align: "left" | "center" | "right" = "left") => ({
-  font: { sz: 9, name: "Arial" },
+  font: { sz: 10, name: "Arial" },
   fill: even ? { fgColor: { rgb: LIGHT_BLUE } } : undefined,
   border: bdr(),
   alignment: { horizontal: align, vertical: "center" as const },
 });
 
-const totalS = () => ({
-  font: { bold: true, sz: 10, name: "Arial" },
-  fill: { fgColor: { rgb: AMBER } },
-  border: bdr(),
-});
-
-const COL_HDRS = [
-  "S.No.", "Bill No.", "Invoice Date", "Party Name", "GST Number",
-  "Commodity", "HSN Code", "GST Rate", "Qty (gm)", "Rate (\u20b9/gm)",
-  "Taxable Value (\u20b9)", "CGST (\u20b9)", "SGST (\u20b9)", "IGST (\u20b9)", "Total Invoice Value (\u20b9)",
-];
-
-const COL_W = [
-  { wch: 6 }, { wch: 12 }, { wch: 13 }, { wch: 30 }, { wch: 20 },
-  { wch: 26 }, { wch: 10 }, { wch: 10 }, { wch: 12 }, { wch: 14 },
-  { wch: 18 }, { wch: 12 }, { wch: 12 }, { wch: 12 }, { wch: 22 },
-];
-
-const TC = 15;
-
 function sc(ws: any, r: number, c: number, v: string | number, s: any, z?: string) {
   const addr = XLSX.utils.encode_cell({ r, c });
   const cell: any = { v, s };
-  if (typeof v === "number") { cell.t = "n"; if (z) cell.z = z; } else { cell.t = "s"; }
+  if (typeof v === "number") {
+    cell.t = "n";
+    if (z) cell.z = z;
+  } else {
+    cell.t = "s";
+  }
   ws[addr] = cell;
 }
-
 function fillR(ws: any, r: number, n: number, s: any) {
   for (let c = 0; c < n; c++) {
     const a = XLSX.utils.encode_cell({ r, c });
@@ -65,100 +97,299 @@ function fillR(ws: any, r: number, n: number, s: any) {
   }
 }
 
-const SAMPLE_ROWS = [
-  { sno: 1, bill: "100", date: "01-04-2025", party: "Rajesh Kumar", gst: "08AABCK5461H1ZO", commodity: "Gold Ornaments", hsn: "711319", gstRate: "3%", qty: 5.250, rate: 6500.00 },
-  { sno: 2, bill: "101", date: "05-04-2025", party: "Priya Sharma", gst: "-", commodity: "Silver Ornaments", hsn: "711319", gstRate: "3%", qty: 45.000, rate: 120.00 },
-  { sno: 3, bill: "102", date: "10-04-2025", party: "Deepak Ji Suthar", gst: "08BBDPK1234L1Z5", commodity: "Gold Ornaments", hsn: "711319", gstRate: "3%", qty: 3.150, rate: 7200.00 },
-];
+// 7 required columns + 1 optional Total (everything else is computed by parser)
+const REQUIRED_HEADERS = [
+  "S.No.",
+  "Bill No.",
+  "Invoice Date",
+  "Party Name",
+  "GST Number",
+  "Commodity",
+  "Qty (gm)",
+  "Rate (₹/gm)",
+] as const;
+// Optional column the user can fill if they want to lock in a final total
+// (otherwise the parser auto-computes Taxable / CGST / SGST / Total).
+const OPTIONAL_HEADER = "Total Invoice Value (₹) (optional)";
 
-export function generateSampleExcel(): Blob {
+const COL_W = [
+  { wch: 6 },  // S.No.
+  { wch: 12 }, // Bill No.
+  { wch: 13 }, // Invoice Date
+  { wch: 30 }, // Party Name
+  { wch: 22 }, // GST Number
+  { wch: 22 }, // Commodity
+  { wch: 12 }, // Qty (gm)
+  { wch: 14 }, // Rate (₹/gm)
+  { wch: 24 }, // Total Invoice Value (optional)
+];
+const TC = COL_W.length;
+
+function fyMonthLabel(): string {
+  const d = new Date();
+  return d.toLocaleString("en-US", { month: "short", year: "numeric" });
+}
+function todayDDMMYYYY(): string {
+  const d = new Date();
+  return `${String(d.getDate()).padStart(2, "0")}-${String(d.getMonth() + 1).padStart(2, "0")}-${d.getFullYear()}`;
+}
+
+/**
+ * Build one supply-type sheet for a given firm.
+ */
+function buildFirmSheet(opts: {
+  firmName: string;
+  gstin: string;
+  supplyType: "Outward Supply" | "Inward Supply";
+  monthLabel: string;
+  productNames: string[];
+  withSamples: boolean;
+}): { ws: any; merges: any[] } {
   const ws: any = {};
   const merges: any[] = [];
   let r = 0;
 
-  // Meta rows
-  const metaRows = [
-    "YOUR BUSINESS NAME",
-    "Outward Supply",
-    "Month: Apr 2025",
-    "GSTIN: 08XXXXX1234X1ZX",
-  ];
-  metaRows.forEach((text) => {
-    sc(ws, r, 0, text, metaS());
-    fillR(ws, r, TC, metaS());
-    merges.push({ s: { r, c: 0 }, e: { r, c: TC - 1 } });
-    r++;
-  });
-
-  // Blank row
+  // Row 1: firm name (uppercase title)
+  sc(ws, r, 0, opts.firmName.toUpperCase(), titleS());
+  fillR(ws, r, TC, titleS());
+  merges.push({ s: { r, c: 0 }, e: { r, c: TC - 1 } });
+  r++;
+  // Row 2: GSTIN
+  sc(ws, r, 0, `GSTIN: ${opts.gstin || "(blank)"}`, gstS());
+  fillR(ws, r, TC, gstS());
+  merges.push({ s: { r, c: 0 }, e: { r, c: TC - 1 } });
+  r++;
+  // Row 3: supply type
+  sc(ws, r, 0, opts.supplyType, subS());
+  fillR(ws, r, TC, subS());
+  merges.push({ s: { r, c: 0 }, e: { r, c: TC - 1 } });
+  r++;
+  // Row 4: month
+  sc(ws, r, 0, `Month: ${opts.monthLabel}`, subS());
+  fillR(ws, r, TC, subS());
+  merges.push({ s: { r, c: 0 }, e: { r, c: TC - 1 } });
+  r++;
+  // Row 5: spacer
   r++;
 
-  // Column headers
-  COL_HDRS.forEach((h, c) => sc(ws, r, c, h, hdrS()));
+  // Row 6: column headers (required + 1 optional)
+  REQUIRED_HEADERS.forEach((h, c) => sc(ws, r, c, h, hdrS()));
+  sc(ws, r, REQUIRED_HEADERS.length, OPTIONAL_HEADER, optHdrS());
   r++;
 
-  // Data rows
-  const NF = "#,##0.00";
-  SAMPLE_ROWS.forEach((row, idx) => {
-    const even = idx % 2 === 0;
-    const taxable = Math.round(row.qty * row.rate * 100) / 100;
-    const cgst = Math.round(taxable * 0.015 * 100) / 100;
-    const sgst = cgst;
-    const total = Math.round((taxable + cgst + sgst) * 100) / 100;
+  const headerRowIdx = r - 1; // for data validation reference
+  const dataStartRow = r;
 
-    sc(ws, r, 0, row.sno, dataS(even, "center"));
-    sc(ws, r, 1, row.bill, dataS(even, "center"));
-    sc(ws, r, 2, row.date, dataS(even, "center"));
-    sc(ws, r, 3, row.party, dataS(even, "left"));
-    sc(ws, r, 4, row.gst, dataS(even, "left"));
-    sc(ws, r, 5, row.commodity, dataS(even, "left"));
-    sc(ws, r, 6, row.hsn, dataS(even, "center"));
-    sc(ws, r, 7, row.gstRate, dataS(even, "center"));
-    sc(ws, r, 8, row.qty, dataS(even, "right"), "#,##0.000");
-    sc(ws, r, 9, row.rate, dataS(even, "right"), NF);
-    sc(ws, r, 10, taxable, dataS(even, "right"), NF);
-    sc(ws, r, 11, cgst, dataS(even, "right"), NF);
-    sc(ws, r, 12, sgst, dataS(even, "right"), NF);
-    sc(ws, r, 13, 0, dataS(even, "right"), NF);
-    sc(ws, r, 14, total, dataS(even, "right"), NF);
+  // Sample rows (up to 3) — only if requested
+  if (opts.withSamples && opts.productNames.length > 0) {
+    const samples = [
+      {
+        bill: "1",
+        date: todayDDMMYYYY(),
+        party: "Sample Customer A",
+        gst: "",
+        commodity: opts.productNames[0],
+        qty: 10.0,
+        rate: 6500.0,
+      },
+      {
+        bill: "2",
+        date: todayDDMMYYYY(),
+        party: "Sample Customer B (with GSTIN)",
+        gst: "08AABCK5461H1ZO",
+        commodity: opts.productNames[Math.min(1, opts.productNames.length - 1)],
+        qty: 50.0,
+        rate: 120.0,
+      },
+    ];
+    samples.forEach((row, idx) => {
+      const even = idx % 2 === 0;
+      sc(ws, r, 0, idx + 1, dataS(even, "center"));
+      sc(ws, r, 1, row.bill, dataS(even, "center"));
+      sc(ws, r, 2, row.date, dataS(even, "center"));
+      sc(ws, r, 3, row.party, dataS(even, "left"));
+      sc(ws, r, 4, row.gst, dataS(even, "left"));
+      sc(ws, r, 5, row.commodity, dataS(even, "left"));
+      sc(ws, r, 6, row.qty, dataS(even, "right"), "#,##0.000");
+      sc(ws, r, 7, row.rate, dataS(even, "right"), "#,##0.00");
+      // Leave the optional Total cell blank — parser will compute
+      r++;
+    });
+  }
+
+  // 8 blank rows for the user to fill in
+  const blankCount = 8;
+  for (let i = 0; i < blankCount; i++) {
+    REQUIRED_HEADERS.forEach((_, c) => {
+      sc(ws, r, c, "", dataS(false, c === 0 ? "center" : "left"));
+    });
+    sc(ws, r, REQUIRED_HEADERS.length, "", dataS(false, "right"));
     r++;
-  });
+  }
 
-  // Total row
-  const ts = totalS();
-  const tsr = { ...ts, alignment: { horizontal: "right" as const } };
-  sc(ws, r, 0, "TOTAL", ts);
-  for (let c = 1; c <= 9; c++) sc(ws, r, c, "", ts);
-  merges.push({ s: { r, c: 0 }, e: { r, c: 9 } });
-
-  const totTaxable = SAMPLE_ROWS.reduce((s, row) => s + Math.round(row.qty * row.rate * 100) / 100, 0);
-  const totCgst = Math.round(totTaxable * 0.015 * 100) / 100;
-  const totSgst = totCgst;
-  const totTotal = Math.round((totTaxable + totCgst + totSgst) * 100) / 100;
-
-  sc(ws, r, 10, totTaxable, tsr, NF);
-  sc(ws, r, 11, totCgst, tsr, NF);
-  sc(ws, r, 12, totSgst, tsr, NF);
-  sc(ws, r, 13, 0, tsr, NF);
-  sc(ws, r, 14, totTotal, tsr, NF);
-
-  ws["!ref"] = XLSX.utils.encode_range({ s: { r: 0, c: 0 }, e: { r, c: TC - 1 } });
+  ws["!ref"] = XLSX.utils.encode_range({ s: { r: 0, c: 0 }, e: { r: r - 1, c: TC - 1 } });
   ws["!merges"] = merges;
   ws["!cols"] = COL_W;
+  // Freeze the meta+header rows
+  ws["!freeze"] = { xSplit: 0, ySplit: headerRowIdx + 1, topLeftCell: `A${headerRowIdx + 2}` };
 
-  const wb = XLSX.utils.book_new();
-  XLSX.utils.book_append_sheet(wb, ws, "Sample Data");
+  // Data validation: dropdown for Commodity column from product list
+  if (opts.productNames.length > 0) {
+    const dvRange = `F${dataStartRow + 1}:F${dataStartRow + 50}`; // column F = index 5
+    const list = opts.productNames.slice(0, 200).join(",");
+    (ws as any)["!dataValidation"] = [
+      {
+        type: "list",
+        allowBlank: true,
+        showInputMessage: true,
+        showErrorMessage: true,
+        promptTitle: "Commodity",
+        prompt: "Pick from your Product list. Add new ones via Products page first.",
+        formulae: [`"${list.replace(/"/g, '""').slice(0, 250)}"`],
+        sqref: dvRange,
+      },
+    ];
+  }
 
-  const wbOut = XLSX.write(wb, { bookType: "xlsx", type: "array" });
-  return new Blob([wbOut], { type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" });
+  return { ws, merges };
 }
 
-export function downloadSampleExcel() {
-  const blob = generateSampleExcel();
+/**
+ * Build the "Instructions" cover sheet.
+ */
+function buildInstructionsSheet(opts: { businessCount: number; productCount: number }): any {
+  const ws: any = {};
+  const merges: any[] = [];
+  let r = 0;
+
+  const TITLE = (text: string) => sc(ws, r, 0, text, titleS());
+  const PARA = (text: string, bold = false) =>
+    sc(ws, r, 0, text, {
+      font: { sz: 11, name: "Arial", bold, color: { rgb: bold ? DARK_BLUE : "111111" } },
+      alignment: { horizontal: "left" as const, vertical: "center" as const, wrapText: true },
+    });
+  const NOTE = (text: string) =>
+    sc(ws, r, 0, text, {
+      font: { sz: 10, name: "Arial", italic: true, color: { rgb: GREY_TEXT } },
+      alignment: { horizontal: "left" as const, vertical: "center" as const, wrapText: true },
+    });
+
+  TITLE("HOW TO USE THIS TEMPLATE"); fillR(ws, r, 4, titleS());
+  merges.push({ s: { r, c: 0 }, e: { r, c: 3 } });
+  r += 2;
+
+  PARA(`This template was built for your account — ${opts.businessCount} business(es) and ${opts.productCount} product(s) detected.`, true);
+  r += 2;
+  PARA("REQUIRED COLUMNS (must be filled in every row):", true); r++;
+  ["1.  Bill No.            — your invoice / bill number",
+   "2.  Invoice Date        — DD-MM-YYYY format (e.g. " + todayDDMMYYYY() + ")",
+   "3.  Party Name          — customer / supplier name",
+   "4.  GST Number          — leave blank for unregistered customers",
+   "5.  Commodity           — pick from the dropdown (must be a product in your Product list)",
+   "6.  Qty (gm)            — quantity in grams",
+   "7.  Rate (₹/gm)     — price per gram",
+  ].forEach((line) => { PARA(line); r++; });
+
+  r++;
+  PARA("AUTO-COMPUTED (you don't need to fill these — leave blank):", true); r++;
+  ["•  HSN Code           — looked up from your Product list by Commodity",
+   "•  GST Rate           — looked up from your Product list by Commodity",
+   "•  Taxable Value      — computed as Qty × Rate",
+   "•  CGST / SGST        — computed from GST Rate (intra-state)",
+   "•  IGST               — computed (inter-state, based on customer GSTIN state)",
+   "•  Total              — Taxable + tax components",
+  ].forEach((line) => { PARA(line); r++; });
+
+  r++;
+  PARA("HOW SHEETS WORK:", true); r++;
+  ["•  One sheet per business (firm name + GSTIN pre-filled in row 1-2)",
+   "•  Each firm sheet is tagged Outward Supply (sales) or Inward Supply (purchases)",
+   "•  You can add as many rows below the header as you need",
+   "•  At import time, all sheets are processed; sheets you don't need can stay empty",
+  ].forEach((line) => { PARA(line); r++; });
+
+  r++;
+  NOTE("If a Commodity isn't in your Product list, the row will fail at import — add the product first via Products → Add Product."); r++;
+  NOTE("If a row doesn't have either (Qty + Rate) or a Total Invoice Value, the import skips it.");
+
+  ws["!ref"] = XLSX.utils.encode_range({ s: { r: 0, c: 0 }, e: { r: r + 1, c: 3 } });
+  ws["!merges"] = merges;
+  ws["!cols"] = [{ wch: 80 }, { wch: 20 }, { wch: 20 }, { wch: 20 }];
+  return ws;
+}
+
+/**
+ * Build the workbook bytes (Uint8Array) — testable without browser APIs.
+ */
+export function generateSampleExcelBytes(opts: TemplateOptions = {}): Uint8Array {
+  const businesses: TemplateBusiness[] = (opts.businesses && opts.businesses.length > 0)
+    ? opts.businesses
+    : [{ name: "Your Business Name", gst_number: "" }];
+  const productNames: string[] = (opts.products || []).map((p) => p.name).filter(Boolean);
+  const month = fyMonthLabel();
+  const includeInward = !!opts.includeInward;
+  const withSamples = opts.withSamples !== false;
+
+  const wb = XLSX.utils.book_new();
+
+  // Always start with an Instructions sheet
+  const instructions = buildInstructionsSheet({
+    businessCount: businesses.length,
+    productCount: productNames.length,
+  });
+  XLSX.utils.book_append_sheet(wb, instructions, "Instructions");
+
+  // One sheet per (firm × supply type)
+  for (const biz of businesses) {
+    const gstin = biz.gst_number || biz.gstin || "";
+    // Outward
+    {
+      const { ws } = buildFirmSheet({
+        firmName: biz.name,
+        gstin,
+        supplyType: "Outward Supply",
+        monthLabel: month,
+        productNames,
+        withSamples,
+      });
+      const sheetName = (biz.name + " - OUT").slice(0, 31);
+      XLSX.utils.book_append_sheet(wb, ws, sheetName);
+    }
+    if (includeInward) {
+      const { ws } = buildFirmSheet({
+        firmName: biz.name,
+        gstin,
+        supplyType: "Inward Supply",
+        monthLabel: month,
+        productNames,
+        withSamples,
+      });
+      const sheetName = (biz.name + " - IN").slice(0, 31);
+      XLSX.utils.book_append_sheet(wb, ws, sheetName);
+    }
+  }
+
+  return XLSX.write(wb, { bookType: "xlsx", type: "array" }) as Uint8Array;
+}
+
+/**
+ * Generate the smart import template as an Excel Blob (browser convenience).
+ */
+export function generateSampleExcel(opts: TemplateOptions = {}): Blob {
+  const bytes = generateSampleExcelBytes(opts);
+  return new Blob([bytes], {
+    type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  });
+}
+
+/** Save the workbook to disk. */
+export function downloadSampleExcel(opts: TemplateOptions = {}) {
+  const blob = generateSampleExcel(opts);
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
-  a.download = "invoice-import-template.xlsx";
+  const stamp = new Date().toISOString().slice(0, 10);
+  a.download = `invoice-import-template-${stamp}.xlsx`;
   a.click();
   URL.revokeObjectURL(url);
 }

--- a/sweet-rebuild-suite-main/src/utils/generateSampleExcel.ts
+++ b/sweet-rebuild-suite-main/src/utils/generateSampleExcel.ts
@@ -233,10 +233,15 @@ function buildFirmSheet(opts: {
   // Freeze the meta+header rows
   ws["!freeze"] = { xSplit: 0, ySplit: headerRowIdx + 1, topLeftCell: `A${headerRowIdx + 2}` };
 
-  // Data validation: dropdown for Commodity column from product list
+  // Data validation: dropdown for Commodity column referencing a hidden
+  // products sheet. Inline-string formulae are limited to 255 chars and
+  // can break if a product name contains a comma or quote — using a sheet
+  // reference avoids both issues.
+  // The hidden sheet is built once at the workbook level (see addProductListSheet)
+  // and referenced here by name.
   if (opts.productNames.length > 0) {
     const dvRange = `F${dataStartRow + 1}:F${dataStartRow + 50}`; // column F = index 5
-    const list = opts.productNames.slice(0, 200).join(",");
+    const lastRow = opts.productNames.length;
     (ws as any)["!dataValidation"] = [
       {
         type: "list",
@@ -245,13 +250,29 @@ function buildFirmSheet(opts: {
         showErrorMessage: true,
         promptTitle: "Commodity",
         prompt: "Pick from your Product list. Add new ones via Products page first.",
-        formulae: [`"${list.replace(/"/g, '""').slice(0, 250)}"`],
+        formulae: [`=_ProductList!$A$1:$A$${lastRow}`],
         sqref: dvRange,
       },
     ];
   }
 
   return { ws, merges };
+}
+
+/** Add a hidden _ProductList sheet that data-validation cells reference. */
+function addProductListSheet(wb: XLSX.WorkBook, productNames: string[]) {
+  if (productNames.length === 0) return;
+  const ws: any = {};
+  productNames.forEach((name, i) => {
+    ws[XLSX.utils.encode_cell({ r: i, c: 0 })] = { v: name, t: "s" };
+  });
+  ws["!ref"] = XLSX.utils.encode_range({ s: { r: 0, c: 0 }, e: { r: productNames.length - 1, c: 0 } });
+  XLSX.utils.book_append_sheet(wb, ws, "_ProductList");
+  // Hide the sheet (xlsx-js-style supports !sheets metadata; not all readers
+  // honor it, but Excel/Google Sheets do).
+  if (!wb.Workbook) wb.Workbook = { Sheets: [] };
+  if (!wb.Workbook.Sheets) wb.Workbook.Sheets = [];
+  wb.Workbook.Sheets.push({ name: "_ProductList", Hidden: 1 });
 }
 
 /**
@@ -338,6 +359,10 @@ export function generateSampleExcelBytes(opts: TemplateOptions = {}): Uint8Array
     productCount: productNames.length,
   });
   XLSX.utils.book_append_sheet(wb, instructions, "Instructions");
+
+  // Hidden products list backing the data-validation dropdowns. Must be
+  // appended BEFORE the firm sheets that reference it.
+  addProductListSheet(wb, productNames);
 
   // One sheet per (firm × supply type)
   for (const biz of businesses) {

--- a/sweet-rebuild-suite-main/src/utils/generateSampleExcel.ts
+++ b/sweet-rebuild-suite-main/src/utils/generateSampleExcel.ts
@@ -364,6 +364,29 @@ export function generateSampleExcelBytes(opts: TemplateOptions = {}): Uint8Array
   // appended BEFORE the firm sheets that reference it.
   addProductListSheet(wb, productNames);
 
+  // Excel sheet names: max 31 chars, can't contain : \ / ? * [ ]. We
+  // sanitize biz names + dedupe across the workbook so two firms whose
+  // names collide after truncation don't make book_append_sheet throw or
+  // overwrite a previous sheet.
+  const usedSheetNames = new Set<string>(["_ProductList", "Instructions"]);
+  const safeSheetName = (raw: string): string => {
+    const clean = raw.replace(/[:\\/?*\[\]]/g, "_").slice(0, 31).trim() || "Sheet";
+    if (!usedSheetNames.has(clean)) {
+      usedSheetNames.add(clean);
+      return clean;
+    }
+    // Suffix with _2, _3, ... while still fitting in 31 chars.
+    for (let i = 2; i < 1000; i++) {
+      const suffix = `_${i}`;
+      const candidate = clean.slice(0, 31 - suffix.length) + suffix;
+      if (!usedSheetNames.has(candidate)) {
+        usedSheetNames.add(candidate);
+        return candidate;
+      }
+    }
+    return clean; // give up and let XLSX throw — extreme degenerate case
+  };
+
   // One sheet per (firm × supply type)
   for (const biz of businesses) {
     const gstin = biz.gst_number || biz.gstin || "";
@@ -377,8 +400,7 @@ export function generateSampleExcelBytes(opts: TemplateOptions = {}): Uint8Array
         productNames,
         withSamples,
       });
-      const sheetName = (biz.name + " - OUT").slice(0, 31);
-      XLSX.utils.book_append_sheet(wb, ws, sheetName);
+      XLSX.utils.book_append_sheet(wb, ws, safeSheetName(biz.name + " - OUT"));
     }
     if (includeInward) {
       const { ws } = buildFirmSheet({
@@ -389,8 +411,7 @@ export function generateSampleExcelBytes(opts: TemplateOptions = {}): Uint8Array
         productNames,
         withSamples,
       });
-      const sheetName = (biz.name + " - IN").slice(0, 31);
-      XLSX.utils.book_append_sheet(wb, ws, sheetName);
+      XLSX.utils.book_append_sheet(wb, ws, safeSheetName(biz.name + " - IN"));
     }
   }
 

--- a/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.test.ts
+++ b/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { normalizeDate, toImportReadyInvoices } from "./parseInvoiceExcel";
+import * as XLSX from "xlsx-js-style";
+import { normalizeDate, toImportReadyInvoices, parseInvoiceExcel } from "./parseInvoiceExcel";
 import type { ParsedExcelResult } from "./parseInvoiceExcel";
+import { generateSampleExcelBytes } from "./generateSampleExcel";
 
 describe("normalizeDate", () => {
   it("converts DD-MM-YYYY to YYYY-MM-DD", () => {
@@ -103,5 +105,59 @@ describe("toImportReadyInvoices — Product master lookup", () => {
     expect(inv.totalCGST).toBe(15);
     expect(inv.totalSGST).toBe(15);
     expect(inv.total).toBe(1030);
+  });
+});
+
+describe("parseInvoiceExcel — regression: smart template (no HSN/GST Rate columns)", () => {
+  it("does NOT misread the Rate column as GST Rate when columns are missing", () => {
+    // Smart template has only 8 columns: S.No., Bill, Date, Party, GST,
+    // Commodity, Qty, Rate. Old positional fallback (gst rate at index 7)
+    // would have picked up the Rate value (~14000) and treated it as 14000%.
+    // After fix: gstRate column missing → gstRate = 0, backend resolves from
+    // Product master.
+    const bytes = generateSampleExcelBytes({
+      businesses: [{ name: "F1", gst_number: "08AAA1234A1Z1" }],
+      products: [{ name: "GOLD ORNAMENTS" }],
+      withSamples: true,
+    });
+    // generateSampleExcelBytes returns a Uint8Array; pass as ArrayBuffer
+    const ab = new Uint8Array(bytes).buffer;
+    const result = parseInvoiceExcel(ab);
+
+    expect(result.firms.length).toBeGreaterThan(0);
+    const firm = result.firms[0];
+    expect(firm.invoices.length).toBeGreaterThan(0);
+    for (const inv of firm.invoices) {
+      // gstRate should be 0 (not present in file → backend resolves it)
+      expect(inv.gstRate).toBe(0);
+      // Rate should be the actual Rate value (≥ 100, not weirdly bonkers)
+      // and qty should be a sensible weight
+      if (inv.qty > 0 && inv.rate > 0) {
+        expect(inv.rate).toBeGreaterThan(50); // any realistic rate
+        expect(inv.qty).toBeLessThan(10000); // sanity: not millions
+      }
+    }
+  });
+
+  it("computed CGST stays sane for smart-template imports (Product master lookup)", () => {
+    const bytes = generateSampleExcelBytes({
+      businesses: [{ name: "F1", gst_number: "08AAA1234A1Z1" }],
+      products: [{ name: "GOLD ORNAMENTS" }],
+      withSamples: true,
+    });
+    // generateSampleExcelBytes returns a Uint8Array; pass as ArrayBuffer
+    const ab = new Uint8Array(bytes).buffer;
+    const result = parseInvoiceExcel(ab);
+    const products = [{ name: "GOLD ORNAMENTS", hsn_code: "711319", gst_tax_rate: 0.03 }];
+    const out = toImportReadyInvoices(result, products);
+
+    // Pre-fix bug: CGST would be ~7300× actual on the sample row.
+    // Post-fix: CGST is at most ~5% of taxable.
+    for (const inv of out) {
+      if (inv.subtotal > 0) {
+        const ratio = inv.totalCGST / inv.subtotal;
+        expect(ratio).toBeLessThan(0.1); // way under 10% — realistic CGST is 1.5%
+      }
+    }
   });
 });

--- a/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.test.ts
+++ b/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { normalizeDate } from "./parseInvoiceExcel";
+import { normalizeDate, toImportReadyInvoices } from "./parseInvoiceExcel";
+import type { ParsedExcelResult } from "./parseInvoiceExcel";
 
 describe("normalizeDate", () => {
   it("converts DD-MM-YYYY to YYYY-MM-DD", () => {
@@ -20,5 +21,87 @@ describe("normalizeDate", () => {
 
   it("returns empty string for empty input", () => {
     expect(normalizeDate("")).toBe("");
+  });
+});
+
+describe("toImportReadyInvoices — Product master lookup", () => {
+  function makeParsed(rows: Array<Partial<{ commodity: string; qty: number; rate: number; gstRate: number; totalInvoiceValue: number }>>): ParsedExcelResult {
+    return {
+      firms: [{
+        firmName: "Test Firm",
+        gstin: "08AAGPL3375F1ZO",
+        supplyType: "Outward Supply",
+        month: "Apr 2026",
+        invoices: rows.map((r, i) => ({
+          sNo: i + 1,
+          billNo: String(i + 1),
+          invoiceDate: "2026-04-01",
+          partyName: `Party ${i + 1}`,
+          gstNumber: "",
+          commodity: r.commodity || "GOLD",
+          hsnCode: "",
+          gstRate: r.gstRate ?? 0,
+          qty: r.qty ?? 0,
+          rate: r.rate ?? 0,
+          taxableValue: 0,
+          cgst: 0,
+          sgst: 0,
+          igst: 0,
+          totalInvoiceValue: r.totalInvoiceValue ?? 0,
+        })),
+      }],
+      summary: [],
+    };
+  }
+
+  it("computes taxable + tax + total when only Qty + Rate are present, looking up GST from Product master", () => {
+    const parsed = makeParsed([{ commodity: "GOLD ORNAMENTS", qty: 5, rate: 14000 }]);
+    const products = [{ name: "GOLD ORNAMENTS", hsn_code: "711319", gst_tax_rate: 0.03 }];
+    const out = toImportReadyInvoices(parsed, products);
+    expect(out).toHaveLength(1);
+    const inv = out[0];
+    // 5g × ₹14,000 = ₹70,000 taxable; 3% GST = ₹2,100 (₹1,050 CGST + ₹1,050 SGST); total = ₹72,100
+    expect(inv.subtotal).toBe(70000);
+    expect(inv.totalCGST).toBe(1050);
+    expect(inv.totalSGST).toBe(1050);
+    expect(inv.totalIGST).toBe(0);
+    expect(inv.total).toBe(72100);
+    // Item should have HSN looked up too
+    expect(inv.items[0].hsn).toBe("711319");
+    expect(inv.items[0].gstRate).toBe(3); // 3% (percentage form)
+    expect(inv.items[0].amount).toBe(72100); // gross
+  });
+
+  it("falls back to gstRate from file row when product not in lookup", () => {
+    const parsed = makeParsed([{ commodity: "PLATINUM", qty: 2, rate: 50000, gstRate: 5 }]);
+    const out = toImportReadyInvoices(parsed, []); // empty product map
+    const inv = out[0];
+    // 2 × 50,000 = 100,000; 5% = 5,000 (2,500 CGST + 2,500 SGST); total 105,000
+    expect(inv.subtotal).toBe(100000);
+    expect(inv.totalCGST).toBe(2500);
+    expect(inv.total).toBe(105000);
+  });
+
+  it("leaves zero values when neither file row nor product master has a GST rate", () => {
+    const parsed = makeParsed([{ commodity: "UNKNOWN_THING", qty: 1, rate: 1000 }]);
+    const out = toImportReadyInvoices(parsed, []);
+    const inv = out[0];
+    // Taxable computed (qty*rate) but no GST → no taxes
+    expect(inv.subtotal).toBe(1000);
+    expect(inv.totalCGST).toBe(0);
+    expect(inv.totalSGST).toBe(0);
+    expect(inv.total).toBe(1000); // amount = taxable since taxes are 0
+  });
+
+  it("back-derives taxable from a supplied total + GST rate", () => {
+    const parsed = makeParsed([{ commodity: "GOLD ORNAMENTS", totalInvoiceValue: 1030 }]);
+    const products = [{ name: "GOLD ORNAMENTS", hsn_code: "711319", gst_tax_rate: 0.03 }];
+    const out = toImportReadyInvoices(parsed, products);
+    const inv = out[0];
+    // 1030 / 1.03 = 1000 taxable; 3% = 30 (15 + 15)
+    expect(inv.subtotal).toBe(1000);
+    expect(inv.totalCGST).toBe(15);
+    expect(inv.totalSGST).toBe(15);
+    expect(inv.total).toBe(1030);
   });
 });

--- a/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.ts
+++ b/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.ts
@@ -374,7 +374,11 @@ function buildProductMap(products?: ProductLookup[]) {
   const ci: Record<string, { hsn: string; gstPercent: number }> = {};
   if (!products) return { exact, ci };
 
-  for (const p of products) {
+  // Sort by name so the case-insensitive "first-seen wins" fallback is
+  // deterministic regardless of the API ordering the caller passes in.
+  const sortedProducts = [...products].sort((a, b) => (a.name || "").localeCompare(b.name || ""));
+
+  for (const p of sortedProducts) {
     if (!p.name) continue;
     const hsn = p.hsn || p.hsn_code || "";
     const raw = p.gstRate ?? p.gst_tax_rate ?? 0;

--- a/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.ts
+++ b/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.ts
@@ -347,11 +347,42 @@ export interface ImportReadyInvoice {
   total: number;
 }
 
-export function toImportReadyInvoices(result: ParsedExcelResult): ImportReadyInvoice[] {
+/** Optional Product master used to resolve HSN + GST rate from Commodity name. */
+export interface ProductLookup {
+  /** Product name (case is preserved; lookup is case-insensitive) */
+  name: string;
+  hsn?: string;
+  hsn_code?: string;
+  /** GST rate as decimal (0.03) or percentage (3) — both accepted */
+  gstRate?: number;
+  gst_tax_rate?: number | string;
+}
+
+function buildProductMap(products?: ProductLookup[]) {
+  const map: Record<string, { hsn: string; gstPercent: number }> = {};
+  if (!products) return map;
+  for (const p of products) {
+    if (!p.name) continue;
+    const hsn = p.hsn || p.hsn_code || "";
+    const raw = p.gstRate ?? p.gst_tax_rate ?? 0;
+    const num = typeof raw === "number" ? raw : parseFloat(String(raw)) || 0;
+    // Normalize to percentage (3 means 3%)
+    const gstPercent = num > 1 ? num : num * 100;
+    map[p.name.toLowerCase().trim()] = { hsn, gstPercent };
+  }
+  return map;
+}
+
+export function toImportReadyInvoices(
+  result: ParsedExcelResult,
+  products?: ProductLookup[],
+): ImportReadyInvoice[] {
+  const productMap = buildProductMap(products);
   const invoices: ImportReadyInvoice[] = [];
 
   for (const firm of result.firms) {
     const type: "OUTWARD" | "INWARD" = firm.supplyType.toLowerCase().includes("inward") ? "INWARD" : "OUTWARD";
+    const isInterState = !!firm.gstin && !!firm.gstin.slice(0, 2);
 
     // Group by bill number to handle multi-item invoices
     const byBill = new Map<string, ParsedInvoiceRow[]>();
@@ -363,24 +394,62 @@ export function toImportReadyInvoices(result: ParsedExcelResult): ImportReadyInv
 
     for (const [billNo, rows] of byBill) {
       const firstRow = rows[0];
-      const items = rows.map(row => ({
-        productName: row.commodity || "Item",
-        hsn: row.hsnCode,
-        gstRate: row.gstRate,
-        qty: row.qty,
-        rate: row.rate,
-        unit: "gms", // default for jewellery
-        amount: row.taxableValue,
-        cgst: row.cgst,
-        sgst: row.sgst,
-        igst: row.igst,
-      }));
+      // Inter-state when first 2 chars of customer GSTIN differ from firm GSTIN.
+      // Used to decide CGST+SGST split vs IGST. Defaults to intra-state.
+      const custStateCode = (firstRow.gstNumber || "").slice(0, 2);
+      const firmStateCode = (firm.gstin || "").slice(0, 2);
+      const useIGST = isInterState && custStateCode && firmStateCode && custStateCode !== firmStateCode;
 
-      const subtotal = items.reduce((s, i) => s + i.amount, 0);
-      const totalCGST = items.reduce((s, i) => s + i.cgst, 0);
-      const totalSGST = items.reduce((s, i) => s + i.sgst, 0);
-      const totalIGST = items.reduce((s, i) => s + i.igst, 0);
-      // Use the total from the first row if available (handles round-off), else calculate
+      const items = rows.map(row => {
+        // Resolve GST% (in percentage form): row → product → 0
+        let gstPercent = row.gstRate;
+        if (!gstPercent || gstPercent === 0) {
+          const lookup = productMap[(row.commodity || "").toLowerCase().trim()];
+          if (lookup) gstPercent = lookup.gstPercent;
+        }
+        const hsn = row.hsnCode || (productMap[(row.commodity || "").toLowerCase().trim()]?.hsn ?? "");
+
+        // Compute taxable: prefer file value → qty*rate → back-derive from total
+        let taxable = row.taxableValue;
+        if (taxable === 0 && row.qty > 0 && row.rate > 0) {
+          taxable = Math.round(row.qty * row.rate * 100) / 100;
+        }
+        if (taxable === 0 && row.totalInvoiceValue > 0 && gstPercent > 0) {
+          taxable = Math.round((row.totalInvoiceValue / (1 + gstPercent / 100)) * 100) / 100;
+        }
+
+        // Compute taxes if not in file
+        let cgst = row.cgst, sgst = row.sgst, igst = row.igst;
+        if (cgst === 0 && sgst === 0 && igst === 0 && taxable > 0 && gstPercent > 0) {
+          if (useIGST) {
+            igst = Math.round(taxable * gstPercent / 100 * 100) / 100;
+          } else {
+            cgst = Math.round(taxable * gstPercent / 200 * 100) / 100; // half rate
+            sgst = cgst;
+          }
+        }
+
+        return {
+          productName: row.commodity || "Item",
+          hsn,
+          gstRate: gstPercent,
+          qty: row.qty,
+          rate: row.rate,
+          unit: "gms",
+          amount: Math.round((taxable + cgst + sgst + igst) * 100) / 100, // GROSS
+          cgst,
+          sgst,
+          igst,
+          // We expose taxable separately via subtotal below — keep amount = gross
+          // so backend's safety net stays consistent.
+          taxable: Math.round(taxable * 100) / 100,
+        } as any;
+      });
+
+      const subtotal = items.reduce((s: number, i: any) => s + (i.taxable ?? 0), 0);
+      const totalCGST = items.reduce((s: number, i: any) => s + i.cgst, 0);
+      const totalSGST = items.reduce((s: number, i: any) => s + i.sgst, 0);
+      const totalIGST = items.reduce((s: number, i: any) => s + i.igst, 0);
       const total = firstRow.totalInvoiceValue > 0
         ? firstRow.totalInvoiceValue
         : Math.round((subtotal + totalCGST + totalSGST + totalIGST) * 100) / 100;
@@ -393,7 +462,11 @@ export function toImportReadyInvoices(result: ParsedExcelResult): ImportReadyInv
         type,
         firmName: firm.firmName,
         firmGSTIN: firm.gstin,
-        items,
+        items: items.map((i: any) => ({
+          productName: i.productName, hsn: i.hsn, gstRate: i.gstRate,
+          qty: i.qty, rate: i.rate, unit: i.unit,
+          amount: i.amount, cgst: i.cgst, sgst: i.sgst, igst: i.igst,
+        })),
         subtotal: Math.round(subtotal * 100) / 100,
         totalCGST: Math.round(totalCGST * 100) / 100,
         totalSGST: Math.round(totalSGST * 100) / 100,

--- a/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.ts
+++ b/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.ts
@@ -369,25 +369,56 @@ export interface ProductLookup {
 }
 
 function buildProductMap(products?: ProductLookup[]) {
-  const map: Record<string, { hsn: string; gstPercent: number }> = {};
-  if (!products) return map;
+  // Two-tier lookup: exact-case first, then case-insensitive fallback.
+  // Surfaces conflicts (e.g. master has BOTH "GOLD COIN" and "gold coin"
+  // with different GST rates) so the import doesn't silently use the wrong
+  // tax rate.
+  const exact: Record<string, { hsn: string; gstPercent: number }> = {};
+  const ci: Record<string, { hsn: string; gstPercent: number }> = {};
+  const ciConflicts: Record<string, Set<number>> = {};
+  if (!products) return { exact, ci, ciConflicts };
+
   for (const p of products) {
     if (!p.name) continue;
     const hsn = p.hsn || p.hsn_code || "";
     const raw = p.gstRate ?? p.gst_tax_rate ?? 0;
     const num = typeof raw === "number" ? raw : parseFloat(String(raw)) || 0;
-    // Normalize to percentage (3 means 3%)
     const gstPercent = num > 1 ? num : num * 100;
-    map[p.name.toLowerCase().trim()] = { hsn, gstPercent };
+
+    const exactKey = p.name.trim();
+    const ciKey = exactKey.toLowerCase();
+    if (!(exactKey in exact)) exact[exactKey] = { hsn, gstPercent };
+
+    if (ciKey in ci) {
+      // Track conflicting GST rates for diagnostics
+      if (Math.abs(ci[ciKey].gstPercent - gstPercent) > 0.001) {
+        if (!ciConflicts[ciKey]) ciConflicts[ciKey] = new Set();
+        ciConflicts[ciKey].add(ci[ciKey].gstPercent);
+        ciConflicts[ciKey].add(gstPercent);
+      }
+      // First-seen wins for case-insensitive — sorted alphabetically by
+      // ProductLookup caller, so uppercase ASCII variants come first
+    } else {
+      ci[ciKey] = { hsn, gstPercent };
+    }
   }
-  return map;
+  return { exact, ci, ciConflicts };
+}
+
+function lookupProduct(
+  commodity: string,
+  maps: ReturnType<typeof buildProductMap>,
+): { hsn: string; gstPercent: number } | undefined {
+  if (!commodity) return undefined;
+  const key = commodity.trim();
+  return maps.exact[key] || maps.ci[key.toLowerCase()];
 }
 
 export function toImportReadyInvoices(
   result: ParsedExcelResult,
   products?: ProductLookup[],
 ): ImportReadyInvoice[] {
-  const productMap = buildProductMap(products);
+  const productMaps = buildProductMap(products);
   const invoices: ImportReadyInvoice[] = [];
 
   for (const firm of result.firms) {
@@ -413,11 +444,11 @@ export function toImportReadyInvoices(
       const items = rows.map(row => {
         // Resolve GST% (in percentage form): row → product → 0
         let gstPercent = row.gstRate;
+        const lookup = lookupProduct(row.commodity, productMaps);
         if (!gstPercent || gstPercent === 0) {
-          const lookup = productMap[(row.commodity || "").toLowerCase().trim()];
           if (lookup) gstPercent = lookup.gstPercent;
         }
-        const hsn = row.hsnCode || (productMap[(row.commodity || "").toLowerCase().trim()]?.hsn ?? "");
+        const hsn = row.hsnCode || (lookup?.hsn ?? "");
 
         // Compute taxable: prefer file value → qty*rate → back-derive from total
         let taxable = row.taxableValue;

--- a/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.ts
+++ b/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.ts
@@ -224,15 +224,14 @@ function parseSheet(ws: XLSX.WorkSheet, sheetName: string): ParsedFirmSheet {
       const hasSNo = colMap.sNo !== undefined;
       const offset = hasSNo ? 0 : -1; // If no S.No column, all columns shift left by 1
 
-      // Use named-column detection (colMap) when available; only fall back to
-      // hardcoded positions for the CORE 7 columns (Bill, Date, Party, GST,
-      // Commodity, Qty, Rate) — and only when colMap is empty (no headers were
-      // detected at all). For optional/derivable columns (HSN, GST Rate,
-      // taxable, CGST/SGST/IGST, Total), if colMap doesn't have them, the
-      // file simply doesn't have them — don't guess at positions, otherwise we
-      // misread Rate as GST Rate when columns shifted.
-      const hasNamedHeaders = Object.keys(colMap).length >= 4;
-
+      // CORE columns (Bill, Date, Party, GST, Commodity, Qty, Rate) keep a
+      // positional fallback for files without recognizable headers — those
+      // 7 are required so we have to find them somewhere. OPTIONAL columns
+      // (HSN, GST Rate, Taxable, CGST/SGST/IGST, Total) read ONLY when
+      // colMap explicitly maps them; otherwise they default to "" / 0 and
+      // the backend resolves from Product master. This prevents misreading
+      // the Rate column as GST Rate when the file has fewer columns than
+      // the legacy template.
       const sNo = colMap.sNo !== undefined ? numVal(row[colMap.sNo]) : 0;
       const billNo = strVal(row[colMap.billNo ?? (hasSNo ? 1 : 0)]);
       const invoiceDate = strVal(row[colMap.invoiceDate ?? (hasSNo ? 2 : 1)]);
@@ -253,8 +252,6 @@ function parseSheet(ws: XLSX.WorkSheet, sheetName: string): ParsedFirmSheet {
       const sgst = colMap.sgst !== undefined ? numVal(row[colMap.sgst]) : 0;
       const igst = colMap.igst !== undefined ? numVal(row[colMap.igst]) : 0;
       const totalInvoiceValue = colMap.total !== undefined ? numVal(row[colMap.total]) : 0;
-      // Suppress lint about hasNamedHeaders if not used (kept for future logic)
-      void hasNamedHeaders;
 
       // Skip blank lines — must have a bill# AND party name AND qty+rate or total
       if (!billNo || !partyName) continue;
@@ -375,8 +372,7 @@ function buildProductMap(products?: ProductLookup[]) {
   // tax rate.
   const exact: Record<string, { hsn: string; gstPercent: number }> = {};
   const ci: Record<string, { hsn: string; gstPercent: number }> = {};
-  const ciConflicts: Record<string, Set<number>> = {};
-  if (!products) return { exact, ci, ciConflicts };
+  if (!products) return { exact, ci };
 
   for (const p of products) {
     if (!p.name) continue;
@@ -388,21 +384,13 @@ function buildProductMap(products?: ProductLookup[]) {
     const exactKey = p.name.trim();
     const ciKey = exactKey.toLowerCase();
     if (!(exactKey in exact)) exact[exactKey] = { hsn, gstPercent };
-
-    if (ciKey in ci) {
-      // Track conflicting GST rates for diagnostics
-      if (Math.abs(ci[ciKey].gstPercent - gstPercent) > 0.001) {
-        if (!ciConflicts[ciKey]) ciConflicts[ciKey] = new Set();
-        ciConflicts[ciKey].add(ci[ciKey].gstPercent);
-        ciConflicts[ciKey].add(gstPercent);
-      }
-      // First-seen wins for case-insensitive — sorted alphabetically by
-      // ProductLookup caller, so uppercase ASCII variants come first
-    } else {
-      ci[ciKey] = { hsn, gstPercent };
-    }
+    // First-seen wins for case-insensitive lookup. Combined with the
+    // exact-case map above, a row with "GOLD COIN" gets the upper-case
+    // entry; "gold coin" gets the lower-case entry; "Gold Coin" falls back
+    // to whichever was declared first in the products[] argument.
+    if (!(ciKey in ci)) ci[ciKey] = { hsn, gstPercent };
   }
-  return { exact, ci, ciConflicts };
+  return { exact, ci };
 }
 
 function lookupProduct(

--- a/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.ts
+++ b/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.ts
@@ -253,9 +253,11 @@ function parseSheet(ws: XLSX.WorkSheet, sheetName: string): ParsedFirmSheet {
       const igst = colMap.igst !== undefined ? numVal(row[colMap.igst]) : 0;
       const totalInvoiceValue = colMap.total !== undefined ? numVal(row[colMap.total]) : 0;
 
-      // Skip blank lines — must have a bill# AND party name AND qty+rate or total
+      // Skip blank lines — must have a bill# AND party name AND at least
+      // one signal of monetary content (qty+rate, total, or taxableValue —
+      // some manual exports only fill the taxable column).
       if (!billNo || !partyName) continue;
-      if ((qty === 0 || rate === 0) && totalInvoiceValue === 0) continue;
+      if ((qty === 0 || rate === 0) && totalInvoiceValue === 0 && taxableValue === 0) continue;
 
       invoices.push({
         sNo: sNo || invoices.length + 1,
@@ -391,7 +393,8 @@ function buildProductMap(products?: ProductLookup[]) {
     // First-seen wins for case-insensitive lookup. Combined with the
     // exact-case map above, a row with "GOLD COIN" gets the upper-case
     // entry; "gold coin" gets the lower-case entry; "Gold Coin" falls back
-    // to whichever was declared first in the products[] argument.
+    // to whichever sorted alphabetically first (since products[] is
+    // pre-sorted by name above for determinism).
     if (!(ciKey in ci)) ci[ciKey] = { hsn, gstPercent };
   }
   return { exact, ci };

--- a/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.ts
+++ b/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.ts
@@ -229,20 +229,29 @@ function parseSheet(ws: XLSX.WorkSheet, sheetName: string): ParsedFirmSheet {
       const invoiceDate = strVal(row[colMap.invoiceDate ?? (hasSNo ? 2 : 1)]);
       const partyName = strVal(row[colMap.partyName ?? (hasSNo ? 3 : 2)]);
       const gstNumber = strVal(row[colMap.gstNumber ?? (hasSNo ? 4 : 3)]);
-      const commodity = strVal(row[colMap.commodity ?? (hasSNo ? 5 : 4)]);
-      const hsnCode = strVal(row[colMap.hsnCode ?? (hasSNo ? 6 : 5)]);
+      // Defaults for jewellery shops if columns missing/empty
+      const commodity = strVal(row[colMap.commodity ?? (hasSNo ? 5 : 4)]) || "Gold Ornaments";
+      const hsnCode = strVal(row[colMap.hsnCode ?? (hasSNo ? 6 : 5)]) || "711319";
       const gstRateStr = strVal(row[colMap.gstRate ?? (hasSNo ? 7 : 6)]).replace("%", "");
-      const gstRate = numVal(gstRateStr);
+      let gstRate = numVal(gstRateStr);
+      if (gstRate === 0) gstRate = 3; // default 3% for jewellery
       const qty = numVal(row[colMap.qty ?? (hasSNo ? 8 : 7)]);
       const rate = numVal(row[colMap.rate ?? (hasSNo ? 9 : 8)]);
 
-      // Taxable value: from column or calculate from qty * rate
+      // Total — read first since we may back-compute from it
+      let totalInvoiceValue = colMap.total !== undefined ? numVal(row[colMap.total]) : (numVal(row[hasSNo ? 14 : 13]) || numVal(row[hasSNo ? 15 : 14]));
+
+      // Taxable: from column → qty*rate → back-calc from total
       let taxableValue = colMap.taxableValue !== undefined ? numVal(row[colMap.taxableValue]) : numVal(row[hasSNo ? 10 : 9]);
       if (taxableValue === 0 && qty > 0 && rate > 0) {
         taxableValue = Math.round(qty * rate * 100) / 100;
       }
+      if (taxableValue === 0 && totalInvoiceValue > 0) {
+        // Back-calc from total: taxable = total / (1 + gst%)
+        taxableValue = Math.round((totalInvoiceValue / (1 + gstRate / 100)) * 100) / 100;
+      }
 
-      // Tax values - from columns or calculate
+      // Tax values — from columns or auto-compute from gst rate
       let cgst = colMap.cgst !== undefined ? numVal(row[colMap.cgst]) : numVal(row[hasSNo ? 11 : 10]);
       let sgst = colMap.sgst !== undefined ? numVal(row[colMap.sgst]) : numVal(row[hasSNo ? 12 : 11]);
       let igst = colMap.igst !== undefined ? numVal(row[colMap.igst]) : numVal(row[hasSNo ? 13 : 12]);
@@ -253,14 +262,14 @@ function parseSheet(ws: XLSX.WorkSheet, sheetName: string): ParsedFirmSheet {
         sgst = Math.round(taxableValue * halfRate / 100 * 100) / 100;
       }
 
-      // Total: from column or calculate
-      let totalInvoiceValue = colMap.total !== undefined ? numVal(row[colMap.total]) : (numVal(row[hasSNo ? 14 : 13]) || numVal(row[hasSNo ? 15 : 14]));
+      // Total: if still 0, derive from taxable + tax components
       if (totalInvoiceValue === 0 && taxableValue > 0) {
         totalInvoiceValue = Math.round((taxableValue + cgst + sgst + igst) * 100) / 100;
       }
 
-      // Skip if no meaningful data
-      if (!billNo && !partyName && qty === 0) continue;
+      // Skip if no meaningful data — must have a bill# OR party name AND some price signal
+      if (!billNo && !partyName) continue;
+      if (qty === 0 && rate === 0 && totalInvoiceValue === 0) continue;
 
       invoices.push({
         sNo: sNo || invoices.length + 1,

--- a/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.ts
+++ b/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.ts
@@ -224,27 +224,37 @@ function parseSheet(ws: XLSX.WorkSheet, sheetName: string): ParsedFirmSheet {
       const hasSNo = colMap.sNo !== undefined;
       const offset = hasSNo ? 0 : -1; // If no S.No column, all columns shift left by 1
 
+      // Use named-column detection (colMap) when available; only fall back to
+      // hardcoded positions for the CORE 7 columns (Bill, Date, Party, GST,
+      // Commodity, Qty, Rate) — and only when colMap is empty (no headers were
+      // detected at all). For optional/derivable columns (HSN, GST Rate,
+      // taxable, CGST/SGST/IGST, Total), if colMap doesn't have them, the
+      // file simply doesn't have them — don't guess at positions, otherwise we
+      // misread Rate as GST Rate when columns shifted.
+      const hasNamedHeaders = Object.keys(colMap).length >= 4;
+
       const sNo = colMap.sNo !== undefined ? numVal(row[colMap.sNo]) : 0;
       const billNo = strVal(row[colMap.billNo ?? (hasSNo ? 1 : 0)]);
       const invoiceDate = strVal(row[colMap.invoiceDate ?? (hasSNo ? 2 : 1)]);
       const partyName = strVal(row[colMap.partyName ?? (hasSNo ? 3 : 2)]);
       const gstNumber = strVal(row[colMap.gstNumber ?? (hasSNo ? 4 : 3)]);
-      // Read raw values — NO silent defaults. The backend looks up HSN + GST rate
-      // from the Product master via the commodity name.
       const commodity = strVal(row[colMap.commodity ?? (hasSNo ? 5 : 4)]);
-      const hsnCode = strVal(row[colMap.hsnCode ?? (hasSNo ? 6 : 5)]);
-      const gstRateStr = strVal(row[colMap.gstRate ?? (hasSNo ? 7 : 6)]).replace("%", "");
-      const gstRate = numVal(gstRateStr); // 0 if not provided — backend resolves
-      const qty = numVal(row[colMap.qty ?? (hasSNo ? 8 : 7)]);
-      const rate = numVal(row[colMap.rate ?? (hasSNo ? 9 : 8)]);
+      const qty = colMap.qty !== undefined ? numVal(row[colMap.qty]) : numVal(row[hasSNo ? 8 : 7]);
+      const rate = colMap.rate !== undefined ? numVal(row[colMap.rate]) : numVal(row[hasSNo ? 9 : 8]);
 
-      // Read columns if present; otherwise leave 0 and let the backend compute
-      // them after resolving the GST rate from Product master.
-      let taxableValue = colMap.taxableValue !== undefined ? numVal(row[colMap.taxableValue]) : numVal(row[hasSNo ? 10 : 9]);
-      let cgst = colMap.cgst !== undefined ? numVal(row[colMap.cgst]) : numVal(row[hasSNo ? 11 : 10]);
-      let sgst = colMap.sgst !== undefined ? numVal(row[colMap.sgst]) : numVal(row[hasSNo ? 12 : 11]);
-      let igst = colMap.igst !== undefined ? numVal(row[colMap.igst]) : numVal(row[hasSNo ? 13 : 12]);
-      let totalInvoiceValue = colMap.total !== undefined ? numVal(row[colMap.total]) : (numVal(row[hasSNo ? 14 : 13]) || numVal(row[hasSNo ? 15 : 14]));
+      // OPTIONAL columns — only read if the header explicitly maps them.
+      // If they're missing, leave blank (parser/backend resolves from Product master).
+      const hsnCode = colMap.hsnCode !== undefined ? strVal(row[colMap.hsnCode]) : "";
+      const gstRate = colMap.gstRate !== undefined
+        ? numVal(strVal(row[colMap.gstRate]).replace("%", ""))
+        : 0;
+      const taxableValue = colMap.taxableValue !== undefined ? numVal(row[colMap.taxableValue]) : 0;
+      const cgst = colMap.cgst !== undefined ? numVal(row[colMap.cgst]) : 0;
+      const sgst = colMap.sgst !== undefined ? numVal(row[colMap.sgst]) : 0;
+      const igst = colMap.igst !== undefined ? numVal(row[colMap.igst]) : 0;
+      const totalInvoiceValue = colMap.total !== undefined ? numVal(row[colMap.total]) : 0;
+      // Suppress lint about hasNamedHeaders if not used (kept for future logic)
+      void hasNamedHeaders;
 
       // Skip blank lines — must have a bill# AND party name AND qty+rate or total
       if (!billNo || !partyName) continue;

--- a/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.ts
+++ b/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.ts
@@ -376,9 +376,14 @@ function buildProductMap(products?: ProductLookup[]) {
   const ci: Record<string, { hsn: string; gstPercent: number }> = {};
   if (!products) return { exact, ci };
 
-  // Sort by name so the case-insensitive "first-seen wins" fallback is
-  // deterministic regardless of the API ordering the caller passes in.
-  const sortedProducts = [...products].sort((a, b) => (a.name || "").localeCompare(b.name || ""));
+  // Sort by lowercased name with locale-independent comparison so the
+  // case-insensitive "first-seen wins" fallback is deterministic across
+  // user environments (localeCompare() varies by ICU/locale).
+  const sortedProducts = [...products].sort((a, b) => {
+    const an = (a.name || "").toLowerCase();
+    const bn = (b.name || "").toLowerCase();
+    return an < bn ? -1 : an > bn ? 1 : 0;
+  });
 
   for (const p of sortedProducts) {
     if (!p.name) continue;

--- a/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.ts
+++ b/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.ts
@@ -229,47 +229,26 @@ function parseSheet(ws: XLSX.WorkSheet, sheetName: string): ParsedFirmSheet {
       const invoiceDate = strVal(row[colMap.invoiceDate ?? (hasSNo ? 2 : 1)]);
       const partyName = strVal(row[colMap.partyName ?? (hasSNo ? 3 : 2)]);
       const gstNumber = strVal(row[colMap.gstNumber ?? (hasSNo ? 4 : 3)]);
-      // Defaults for jewellery shops if columns missing/empty
-      const commodity = strVal(row[colMap.commodity ?? (hasSNo ? 5 : 4)]) || "Gold Ornaments";
-      const hsnCode = strVal(row[colMap.hsnCode ?? (hasSNo ? 6 : 5)]) || "711319";
+      // Read raw values — NO silent defaults. The backend looks up HSN + GST rate
+      // from the Product master via the commodity name.
+      const commodity = strVal(row[colMap.commodity ?? (hasSNo ? 5 : 4)]);
+      const hsnCode = strVal(row[colMap.hsnCode ?? (hasSNo ? 6 : 5)]);
       const gstRateStr = strVal(row[colMap.gstRate ?? (hasSNo ? 7 : 6)]).replace("%", "");
-      let gstRate = numVal(gstRateStr);
-      if (gstRate === 0) gstRate = 3; // default 3% for jewellery
+      const gstRate = numVal(gstRateStr); // 0 if not provided — backend resolves
       const qty = numVal(row[colMap.qty ?? (hasSNo ? 8 : 7)]);
       const rate = numVal(row[colMap.rate ?? (hasSNo ? 9 : 8)]);
 
-      // Total — read first since we may back-compute from it
-      let totalInvoiceValue = colMap.total !== undefined ? numVal(row[colMap.total]) : (numVal(row[hasSNo ? 14 : 13]) || numVal(row[hasSNo ? 15 : 14]));
-
-      // Taxable: from column → qty*rate → back-calc from total
+      // Read columns if present; otherwise leave 0 and let the backend compute
+      // them after resolving the GST rate from Product master.
       let taxableValue = colMap.taxableValue !== undefined ? numVal(row[colMap.taxableValue]) : numVal(row[hasSNo ? 10 : 9]);
-      if (taxableValue === 0 && qty > 0 && rate > 0) {
-        taxableValue = Math.round(qty * rate * 100) / 100;
-      }
-      if (taxableValue === 0 && totalInvoiceValue > 0) {
-        // Back-calc from total: taxable = total / (1 + gst%)
-        taxableValue = Math.round((totalInvoiceValue / (1 + gstRate / 100)) * 100) / 100;
-      }
-
-      // Tax values — from columns or auto-compute from gst rate
       let cgst = colMap.cgst !== undefined ? numVal(row[colMap.cgst]) : numVal(row[hasSNo ? 11 : 10]);
       let sgst = colMap.sgst !== undefined ? numVal(row[colMap.sgst]) : numVal(row[hasSNo ? 12 : 11]);
       let igst = colMap.igst !== undefined ? numVal(row[colMap.igst]) : numVal(row[hasSNo ? 13 : 12]);
+      let totalInvoiceValue = colMap.total !== undefined ? numVal(row[colMap.total]) : (numVal(row[hasSNo ? 14 : 13]) || numVal(row[hasSNo ? 15 : 14]));
 
-      if (cgst === 0 && sgst === 0 && igst === 0 && taxableValue > 0 && gstRate > 0) {
-        const halfRate = gstRate / 2;
-        cgst = Math.round(taxableValue * halfRate / 100 * 100) / 100;
-        sgst = Math.round(taxableValue * halfRate / 100 * 100) / 100;
-      }
-
-      // Total: if still 0, derive from taxable + tax components
-      if (totalInvoiceValue === 0 && taxableValue > 0) {
-        totalInvoiceValue = Math.round((taxableValue + cgst + sgst + igst) * 100) / 100;
-      }
-
-      // Skip if no meaningful data — must have a bill# OR party name AND some price signal
-      if (!billNo && !partyName) continue;
-      if (qty === 0 && rate === 0 && totalInvoiceValue === 0) continue;
+      // Skip blank lines — must have a bill# AND party name AND qty+rate or total
+      if (!billNo || !partyName) continue;
+      if ((qty === 0 || rate === 0) && totalInvoiceValue === 0) continue;
 
       invoices.push({
         sNo: sNo || invoices.length + 1,

--- a/sweet-rebuild-suite-main/src/utils/utils.ts
+++ b/sweet-rebuild-suite-main/src/utils/utils.ts
@@ -4,3 +4,7 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function pluralize(n: number, singular: string, plural?: string): string {
+  return `${n} ${n === 1 ? singular : (plural ?? `${singular}s`)}`;
+}


### PR DESCRIPTION
# Import flow polish: bug fixes, perf, error visibility, CI

## Summary

15 commits worth of polish on the import flow + supporting infrastructure. Started as a few backend bug fixes, expanded to cover the entire CSV/Excel import pipeline, error visibility, perf, and a CI workflow. **Do not merge yet — review only.**

## Bug fixes

### Import correctness
- **Parser misread Rate as GST Rate** — smart template has 8 columns (no HSN, no GST Rate); the old positional fallback read column 7 (Rate) as gstRate, producing 7000%+ tax on jewellery imports. Now only named-header columns are trusted; missing optional columns default to 0 and the backend resolves from Product master.
- **Import preview showed ₹0 for taxes** — `ImportPage` was passing wrong field names (`hsn_code`/`gst_tax_rate`) to the parser, but `mapDjangoProduct` had renamed them to `hsn`/`gstRate`. Product map ended up empty, taxes weren't computed.
- **Dedup key missed invoice type** — sales bill #1 and purchase bill #1 were being marked as duplicates. Added `type_of_invoice` to the dedup key on both frontend and backend.
- **Product lookup non-deterministic** — when the master had `GOLD COIN` 3% AND `gold coin` 12%, the lowercase one (last write) won. Now exact-case match wins, with a case-insensitive fallback.
- **Customer create requires `businesses`** — was 400-ing legitimate API calls. Made the M2M field optional in the serializer.
- **AuditLog Undo crashed on FK names** — `int("LODHA JEWELLERS")` fails. Snapshots now store FK column IDs, and undo has a defensive name-lookup fallback for legacy snapshots.
- **Invoice edit corrupted totals** — front-end sent `LineItem.amount` as NET; backend computes `Invoice.total_amount = sum(LineItem.amount)`, so totals shrank by ~3% (the GST) on every edit. Now sends GROSS.
- **Bulk import overflow gave 500** — one bad row would crash the whole batch with psycopg2 numeric overflow. Now each row is validated against column precision; bad rows surface in `errors[]` instead.
- **No silent defaults in import** — refused to invent HSN/GST rate values. If a commodity isn't in the Product master, the row fails with a clear error pointing the user to add the product first.

### UX
- **IGST column missing from import review** — inter-state rows looked like 0 tax. Added IGST column with dimmed-zero styling for unused tax columns per row.
- **GST Rate column added** to both pre- and post-import tables, with multi-rate display (`3%/5%`) for mixed invoices.
- **Tax Distribution chart overflowed** its container — replaced outer leader-line labels with inline legend amounts.
- **Monthly Trend tooltip** showed JS float noise (`6107.1684000000005`). Rounded to 3 dp at data and tooltip layers.
- **Toast formatter handles HTML responses** — Django debug-page 500s used to render the entire HTML page in the toast. Now extracts the exception message.
- **Bulk-import errors surface to UI + audit log** — failed rows show in toast with first 3 reasons + count of remaining; also written to AuditLog so they appear on the Audit Log page.
- **Sort fixes** — invoice numbers sorted as strings (`"10" < "9"`). Now uses `localeCompare(..., { numeric: true })` in both Excel export and InvoiceList.

## Performance

- **Bulk import 4×–10× faster**:
  - 23-invoice import: ~30s → ~1.5s (~200 round trips → ~10)
  - 10-invoice import with all-new customers: 4665ms → 1059ms
  - Pre-fetch businesses/customers/duplicates in batches; bulk_create for customers, invoices, line items, audit logs, and the Customer↔Business through table; `_raw_delete` skips redundant signal SELECT; safety-net SQL re-derives totals from line items.
- **Invoice update 4× faster**:
  - Combined PATCH + update_line_items into a single endpoint
  - Removed redundant `Invoice.save()`'s `sum()` query (post_save signal already keeps totals in sync)
  - `AuditLogMixin.perform_update` no longer calls `get_object()` + `refresh_from_db()` redundantly
  - End-to-end edit time: 3.4s → 770ms.
- **Customer/Invoice CRUD ~50% faster** via the same audit mixin fix.

## Smart import template

- One sheet per business, pre-filled with the user's actual firm names + GSTINs
- Optional Inward sheets via "+ Inward sheets too" button
- "Instructions" cover sheet explaining required vs auto-computed columns
- Excel data validation dropdown for Commodity, sourced from the user's Product master
- Filename includes a date stamp
- 7 unit tests cover the structure (instructions sheet, per-business sheets, inward toggle, GSTIN/name pre-fill, sample products, fallback when no data, exact column set)

## Error visibility

- New `utils/apiError.ts` formats DRF errors uniformly (detail / error / message / field-level / arrays / strings / HTML)
- Rolled out across 8 files (was ad-hoc per page)
- Toast durations extended to 12-15s for failures so error text is readable

## CI

- Added `.github/workflows/test.yml` running backend pytest + frontend vitest + Playwright E2E in a fresh Ubuntu VM with in-runner Postgres on every push to main/polish/new_ui

## Test plan

- [ ] Drop the fresh comprehensive test file (`test-import-fresh-*.xlsx`) into Invoices → Import. Should preview 50 rows, 0 duplicates, all "New Customer", correct CGST/SGST/IGST per row.
- [ ] Click Import. Toast says "Imported 50, 0 skipped". Verify per-row math via the audit log entries.
- [ ] Edit any imported invoice — Update completes in <1s and total stays correct.
- [ ] Reports → Monthly Trend tooltip shows 3-decimal numbers, no float noise.
- [ ] Reports → Tax Distribution chart fits in container, no overflow.
- [ ] Audit log shows each import event + per-row failure entries (if any).
- [ ] Run `pytest billing/` and `cd sweet-rebuild-suite-main && npm test` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
