### PR TITLE
feat(notifications): wire up GST compliance scanner

### DIFF
--- a/sweet-rebuild-suite-main/src/components/AppLayout.tsx
+++ b/sweet-rebuild-suite-main/src/components/AppLayout.tsx
@@ -11,6 +11,7 @@ import EasyBottomNav from "./mobile/easy/EasyBottomNav";
 import { MobileModeProvider, useMobileMode } from "@/contexts/MobileModeContext";
 import SkipToContent from "./SkipToContent";
 import ErrorBoundary from "./ErrorBoundary";
+import { useComplianceScanner } from "@/hooks/useComplianceScanner";
 
 export const FYContext = { selectedFY: currentFY };
 
@@ -26,6 +27,11 @@ function AppLayoutInner() {
   const isMobile = useIsMobile();
   const { mobileMode } = useMobileMode();
   FYContext.selectedFY = selectedFY;
+
+  // Scan for actionable GST compliance signals once per day and surface them
+  // through the existing notification bell. Skips silently when offline /
+  // logged out / already ran today.
+  useComplianceScanner();
 
   const isEasy = isMobile && mobileMode === "easy";
 

--- a/sweet-rebuild-suite-main/src/hooks/useComplianceScanner.ts
+++ b/sweet-rebuild-suite-main/src/hooks/useComplianceScanner.ts
@@ -1,0 +1,95 @@
+import { useEffect, useRef } from "react";
+import { logger } from "@/utils/logger";
+import api from "@/utils/api";
+import { pushNotification } from "@/hooks/useNotifications";
+import { currentFY } from "@/utils/mockData";
+
+/**
+ * On-demand GST compliance scanner.
+ *
+ * Hits the gst_summary endpoint once per session (per-day stable IDs make
+ * notifications dedup themselves across reloads), turns the result into
+ * actionable notifications:
+ *
+ *   - itc-aging-urgent-{YYYY-MM-DD}   — N invoices ≤ 60 days from Sec 16(4)
+ *                                       cutoff (ITC will be forfeit if not
+ *                                       claimed)
+ *   - itc-aging-expired-{YYYY-MM-DD}  — N invoices already past cutoff
+ *   - gstr1-3b-mismatch-{YYYY-MM-DD}  — variance > ₹0.50 between rate-slab
+ *                                       tax and Output Tax (Rule 88C / DRC-01B
+ *                                       blocker if it grows past ₹25L)
+ *
+ * The scanner skips silently when:
+ *   - user is logged out
+ *   - already ran today (gst_compliance_scan_date in localStorage)
+ *
+ * It runs against the *current* FY. Cross-FY checks are a follow-up — most
+ * compliance signals are FY-bound anyway (Sec 16(4) cutoff lives in next FY's
+ * Nov 30, but the relevant *invoices* are in the current FY).
+ */
+export function useComplianceScanner() {
+  const ran = useRef(false);
+
+  useEffect(() => {
+    if (ran.current) return;
+    ran.current = true;
+
+    if (!localStorage.getItem("gst_access_token")) return;
+
+    const today = new Date().toISOString().slice(0, 10);
+    const lastScan = localStorage.getItem("gst_compliance_scan_date");
+    if (lastScan === today) return;
+
+    const fyStart = parseInt(currentFY.split("-")[0], 10);
+    const params = new URLSearchParams({
+      start_date: `${fyStart}-04-01`,
+      end_date: `${fyStart + 1}-03-31`,
+    });
+
+    api.get<any>(`invoices/gst_summary/?${params.toString()}`)
+      .then((res) => {
+        const data = res.data || {};
+        const aging = data.itc_aging?.buckets || {};
+        const recon = data.gstr1_3b_recon || {};
+
+        // ITC aging — urgent (≤60 days)
+        const urgentCount = aging.fresh?.count || 0;
+        if (urgentCount > 0) {
+          pushNotification({
+            stableId: `itc-aging-urgent-${today}`,
+            type: "warning",
+            title: `${urgentCount} invoice${urgentCount === 1 ? "" : "s"} near Sec 16(4) cutoff`,
+            message: `ITC worth ₹${(aging.fresh?.tax || 0).toLocaleString("en-IN")} will be forfeit within 60 days if not claimed. Open GST → ITC Aging.`,
+          });
+        }
+
+        // ITC aging — already expired
+        const expiredCount = aging.expired?.count || 0;
+        if (expiredCount > 0) {
+          pushNotification({
+            stableId: `itc-aging-expired-${today}`,
+            type: "error",
+            title: `${expiredCount} invoice${expiredCount === 1 ? "" : "s"} past ITC cutoff`,
+            message: `ITC of ₹${(aging.expired?.tax || 0).toLocaleString("en-IN")} is forfeit per Sec 16(4). Review in GST → ITC Aging.`,
+          });
+        }
+
+        // GSTR-1 vs GSTR-3B variance
+        const variance = Math.abs(recon.variance || 0);
+        if (variance > 0.5) {
+          const severe = variance > 2_500_000;  // Rule 88C / DRC-01B threshold
+          pushNotification({
+            stableId: `gstr1-3b-mismatch-${today}`,
+            type: severe ? "error" : "warning",
+            title: severe ? "GSTR-1 vs 3B mismatch — filing risk" : "GSTR-1 vs 3B mismatch",
+            message: severe
+              ? `Variance of ₹${variance.toLocaleString("en-IN")} exceeds the Rule 88C / DRC-01B threshold (₹25L). This can block your next-period GSTR-3B.`
+              : `Rate-slab tax differs from GSTR-3B Output Tax by ₹${variance.toLocaleString("en-IN")}. Open GST to investigate.`,
+          });
+        }
+
+        localStorage.setItem("gst_compliance_scan_date", today);
+      })
+      .catch((e) => logger.warn("Compliance scan failed", e));
+  }, []);
+}

--- a/sweet-rebuild-suite-main/src/hooks/useNotifications.ts
+++ b/sweet-rebuild-suite-main/src/hooks/useNotifications.ts
@@ -24,14 +24,25 @@ function saveNotifications(notifications: AppNotification[]) {
 export function useNotifications() {
   const [notifications, setNotifications] = useState<AppNotification[]>(loadNotifications);
 
-  const add = useCallback((n: Omit<AppNotification, "id" | "timestamp" | "read">) => {
-    const newNotification: AppNotification = {
-      ...n,
-      id: crypto.randomUUID().slice(0, 8),
-      timestamp: Date.now(),
-      read: false,
-    };
+  /**
+   * Add a notification. If `stableId` is supplied (e.g. "itc-aging-2026-05-10"),
+   * we skip when a notification with that ID already exists — letting compliance
+   * scanners run on every load without spamming the user. Random UUID is used
+   * when no stableId is provided.
+   */
+  const add = useCallback((n: Omit<AppNotification, "id" | "timestamp" | "read"> & { stableId?: string }) => {
     setNotifications((prev) => {
+      if (n.stableId && prev.some((existing) => existing.id === n.stableId)) {
+        return prev;  // dedup
+      }
+      const newNotification: AppNotification = {
+        type: n.type,
+        title: n.title,
+        message: n.message,
+        id: n.stableId || crypto.randomUUID().slice(0, 8),
+        timestamp: Date.now(),
+        read: false,
+      };
       const updated = [newNotification, ...prev].slice(0, 50);
       saveNotifications(updated);
       return updated;
@@ -75,6 +86,6 @@ export function useNotifications() {
 }
 
 // Helper to dispatch notification from anywhere
-export function pushNotification(n: Omit<AppNotification, "id" | "timestamp" | "read">) {
+export function pushNotification(n: Omit<AppNotification, "id" | "timestamp" | "read"> & { stableId?: string }) {
   window.dispatchEvent(new CustomEvent("app-notification", { detail: n }));
 }


### PR DESCRIPTION
The notification bell + center has been live for a while but nothing actually fired notifications — `pushNotification` had **zero call-sites**. This PR turns the bell into a real GST compliance assistant.

Stacks on [#67](https://github.com/Vaibhav159/gst_billing/pull/67) — uses the new `itc_aging` and `gstr1_3b_recon` payload that PR added to \`/invoices/gst_summary/\`.

## What lights the bell now

\`useComplianceScanner\` runs once per AppLayout mount (skipped when already ran today, gated by \`gst_compliance_scan_date\` in localStorage) and surfaces three notification classes:

| Class | Trigger | Severity |
|---|---|---|
| **Sec 16(4) cutoff approaching** | N inward invoices ≤ 60 days from cutoff | warning |
| **Sec 16(4) cutoff past** | N invoices already forfeit | error |
| **GSTR-1 vs 3B mismatch** | variance > ₹0.50 between rate-slab tax & Output Tax | warning, escalates to **error** above ₹25L (Rule 88C / DRC-01B threshold) |

Each message includes the rupee exposure / variance amount + a hint to check the GST page.

## Plumbing changes

- \`useNotifications.add()\` now accepts an optional \`stableId\`. When supplied, we no-op if a notification with that ID already exists. Fixes the \"reload spams the same notification\" trap.
- \`pushNotification()\` global helper passes \`stableId\` through.
- \`useComplianceScanner\` mounted in \`AppLayout\` so it runs on every authenticated session, max once per day.

## What's intentionally NOT here

Listed for follow-up:

- Per-event hooks (import success, backup completion) — those already toast; defer until we know which need persistence.
- Cross-FY scans — Sec 16(4) cutoff invoices live in current FY anyway.
- Push notifications via service worker — needs worker registration + permission flow.

## Test plan

- [x] tsc clean
- [x] Scanner runs on AppLayout mount, sets \`gst_compliance_scan_date\`, skips on next reload
- [x] With clean test data (variance=0, all invoices in stale bucket) **zero notifications** fired — correct, no false positives
- [x] Synthetic event fires bell badge to **\"1\"**, panel renders title + message
- [x] Same \`stableId\` fired 3× still dedups to count=1

🤖 Generated with [Claude Code](https://claude.com/claude-code)