### PR TITLE
fix(banner): drop FY scope when data-quality drill-down is active

### DIFF
--- a/sweet-rebuild-suite-main/src/pages/InvoiceList.tsx
+++ b/sweet-rebuild-suite-main/src/pages/InvoiceList.tsx
@@ -63,18 +63,27 @@ export default function InvoiceList() {
   const noHsnFilter = searchParams.get("no_hsn") === "1";
   const hasHygieneFilter = dupsFilter || emptyFilter || noHsnFilter;
 
-  // Build filters object for the API-driven hook
+  // Build filters object for the API-driven hook.
+  //
+  // When a hygiene URL drill-down is active (dups / empty / no_hsn), the
+  // data_quality scan that produced the count was global across all
+  // financial years — but the user might be sitting on FY 2025-26 with
+  // the duplicates living in FY 2023-24 / 2024-25. Without this override
+  // the list would show 0 rows after clicking the DataQualityBanner chip
+  // even though the count said 5. We force fyFilter + monthFilter to
+  // "all" for hygiene drill-downs so the listed invoices match the
+  // count the user came here from.
   const apiFilters: InvoiceFilters = useMemo(() => ({
     search: debouncedSearch || undefined,
     businessId: bizFilter,
     customerId: custFilter,
     typeFilter,
-    fyFilter,
-    monthFilter,
+    fyFilter: hasHygieneFilter ? "all" : fyFilter,
+    monthFilter: hasHygieneFilter ? "all" : monthFilter,
     dups: dupsFilter || undefined,
     empty: emptyFilter || undefined,
     noHsn: noHsnFilter || undefined,
-  }), [debouncedSearch, bizFilter, custFilter, typeFilter, fyFilter, monthFilter, dupsFilter, emptyFilter, noHsnFilter]);
+  }), [debouncedSearch, bizFilter, custFilter, typeFilter, fyFilter, monthFilter, dupsFilter, emptyFilter, noHsnFilter, hasHygieneFilter]);
 
   const { items: invoices, remove: removeInvoice, isLoading, isLoadingMore, hasMore, loadMore, totalCount } = useInvoices(apiFilters);
   const { data: statsData, isLoading: isStatsLoading } = useDashboardStats(apiFilters);
@@ -391,7 +400,7 @@ export default function InvoiceList() {
           <SlidersHorizontal className="w-4 h-4 text-warning shrink-0" />
           <div className="flex-1 min-w-0">
             <p className="text-[13px] font-semibold text-foreground">Filtered: {hygieneFilterLabel}</p>
-            <p className="text-[11px] text-muted-foreground">Showing only invoices flagged by data-quality scan.</p>
+            <p className="text-[11px] text-muted-foreground">Showing flagged invoices across all financial years (data-quality scan is global).</p>
           </div>
           <button onClick={clearFilters} className="text-[12px] font-semibold text-primary hover:underline shrink-0">
             Clear filter


### PR DESCRIPTION
## The bug

DataQualityBanner shows global counts (e.g. \"5 duplicate invoice numbers\") scanned across ALL financial years. But clicking through landed the user on \`/billing/invoice/list?dups=1\` with the *current* FY filter still applied.

If the dup invoices lived in older FYs — exactly the case in this dev DB where all 10 dup rows are in FY 2023-24 / 2024-25 — the list came up empty next to a header that said \"5 duplicate invoice numbers\". User reports it as a bug; it absolutely is.

## The fix

When any hygiene URL param (\`dups\`, \`empty\`, \`no_hsn\`) is set, force \`fyFilter\` and \`monthFilter\` to \`\"all\"\` before building the API request. The user came from a global scan; the list view shouldn't re-narrow.

The chip-row banner subtitle now reads:
> Showing flagged invoices across all financial years (data-quality scan is global).

So the FY-widening isn't silent.

## Verified live

\`\`\`
GET /api/invoices/?dups=1                                        → 10 rows
GET /api/invoices/?dups=1&start_date=2025-04-01&end_date=2026-03-31 → 0 rows
\`\`\`

Pre-fix the InvoiceList was sending the second URL. Now it sends the first when \`?dups=1\` is present.

## Test plan

- [ ] On Dashboard, click any chip in the DataQualityBanner (Duplicate / Empty / Missing HSN).
- [ ] Verify the count above the table matches the count on the chip.
- [ ] Verify the FY chip / select still shows your previously-selected FY (only the API request widens; the form value doesn't change).
- [ ] Click \"Clear filter\" — both hygiene params drop and the original FY is back in effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)