### PR TITLE
feat: AI Invoice Import + GSTR-2A bulk import + Excel import polish + UX

### DIFF
--- a/billing/api/views.py
+++ b/billing/api/views.py
@@ -3136,33 +3136,63 @@ class AIInvoiceProcessingView(APIView):
             matched_business = None
             detected_type = None
             our_role: str | None = None  # "buyer" or "seller"
+            inter_firm_buyer = None      # set when BOTH parties are our firms
 
             buyer_gstin = (extracted_data.get("buyer_gst_number") or "").strip().upper()
             seller_gstin = (extracted_data.get("seller_gst_number") or "").strip().upper()
             customer_gstin = (extracted_data.get("customer_gst_number") or "").strip().upper()
 
-            for gstin, role in (
-                (buyer_gstin, "buyer"),
-                (seller_gstin, "seller"),
-                (customer_gstin, "customer"),  # legacy AI fill — usually = buyer
-            ):
-                if not gstin:
-                    continue
-                biz = Business.objects.filter(gst_number=gstin).first()
-                if biz:
-                    matched_business = {
-                        "id": biz.id, "name": biz.name, "gst_number": biz.gst_number,
-                    }
-                    # buyer + customer (the most common AI conflation)
-                    # both mean we were the recipient → INWARD.
-                    our_role = "seller" if role == "seller" else "buyer"
-                    detected_type = (
-                        INVOICE_TYPE_OUTWARD if our_role == "seller"
-                        else INVOICE_TYPE_INWARD
-                    )
-                    break
+            buyer_biz = (
+                Business.objects.filter(gst_number=buyer_gstin).first()
+                if buyer_gstin else None
+            )
+            seller_biz = (
+                Business.objects.filter(gst_number=seller_gstin).first()
+                if seller_gstin else None
+            )
+            # Legacy fallback: the AI sometimes only fills the customer_*
+            # fields (usually the buyer — the "Bill To" block is the most
+            # prominent on Indian invoices).
+            if buyer_biz is None and seller_biz is None and customer_gstin:
+                buyer_biz = Business.objects.filter(gst_number=customer_gstin).first()
 
-            if matched_business:
+            if buyer_biz and seller_biz and buyer_biz.id != seller_biz.id:
+                # ── INTER-FIRM: both parties are our businesses. One
+                # physical bill = two ledger entries. Primary is the
+                # OUTWARD for the seller firm; the create endpoint also
+                # writes the INWARD mirror for the buyer firm (see
+                # AIInvoiceCreateView inter_firm handling). Detected
+                # this way, the sale AND the purchase/ITC side both
+                # land without the user importing the bill twice.
+                matched_business = {
+                    "id": seller_biz.id, "name": seller_biz.name,
+                    "gst_number": seller_biz.gst_number,
+                }
+                inter_firm_buyer = {
+                    "id": buyer_biz.id, "name": buyer_biz.name,
+                    "gst_number": buyer_biz.gst_number,
+                }
+                our_role = "seller"
+                detected_type = INVOICE_TYPE_OUTWARD
+                # The outward entry's customer is the buyer firm.
+                extracted_data["customer_name"] = buyer_biz.name
+                extracted_data["customer_gst_number"] = buyer_biz.gst_number
+            elif seller_biz:
+                matched_business = {
+                    "id": seller_biz.id, "name": seller_biz.name,
+                    "gst_number": seller_biz.gst_number,
+                }
+                our_role = "seller"
+                detected_type = INVOICE_TYPE_OUTWARD
+            elif buyer_biz:
+                matched_business = {
+                    "id": buyer_biz.id, "name": buyer_biz.name,
+                    "gst_number": buyer_biz.gst_number,
+                }
+                our_role = "buyer"
+                detected_type = INVOICE_TYPE_INWARD
+
+            if matched_business and not inter_firm_buyer:
                 # Promote the OTHER party into the legacy customer_*
                 # fields the review form binds against. Preference
                 # order: the explicit field for that side → the legacy
@@ -3239,6 +3269,11 @@ class AIInvoiceProcessingView(APIView):
                     "data": extracted_data,
                     "matched_business": matched_business,  # null if no DB match
                     "detected_type": detected_type,        # "inward" / "outward" / null
+                    # Inter-firm: both GSTINs on the bill are OUR firms.
+                    # matched_business is the seller (outward side);
+                    # this is the buyer firm that gets the inward mirror.
+                    "inter_firm": inter_firm_buyer is not None,
+                    "inter_firm_buyer_business": inter_firm_buyer,
                     # Which of the N rotated Gemini keys handled this
                     # request. Lets the UI show "Gemini #2/3" so the
                     # user can see when they're burning through the
@@ -3326,6 +3361,15 @@ class AIInvoiceCreateView(APIView):
                     {"error": "type_of_invoice must be 'outward' or 'inward'"},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
+
+            # Inter-firm: both parties on the bill are our businesses.
+            # The primary invoice (business_id/type above — the seller's
+            # OUTWARD) is created as usual; then an INWARD mirror is
+            # written for the buyer firm so the purchase/ITC side lands
+            # from the same upload. Values arrive as strings when the
+            # request is multipart.
+            inter_firm = str(request.data.get("inter_firm", "")).lower() in ("true", "1")
+            inter_firm_buyer_id = request.data.get("inter_firm_buyer_business_id") or None
 
             try:
                 business = Business.objects.get(id=business_id)
@@ -3422,6 +3466,89 @@ class AIInvoiceCreateView(APIView):
             inv_date = (
                 invoice_data.get("invoice_date") or datetime.now().date()
             )
+            # Inter-firm mirror helper — creates (or finds) the INWARD
+            # entry for the buyer firm, copying lines from the primary
+            # invoice. Used on both the fresh-create path AND the
+            # primary-duplicate path, so re-uploading a bill whose
+            # outward already exists still completes a missing inward
+            # mirror instead of silently skipping it.
+            def ensure_inward_mirror(primary_invoice):
+                if not (inter_firm and inter_firm_buyer_id):
+                    return None, False
+                buyer_business = Business.objects.filter(id=inter_firm_buyer_id).first()
+                if buyer_business is None:
+                    logger.warning("inter_firm buyer business %s not found", inter_firm_buyer_id)
+                    return None, False
+                supplier_cust = None
+                if business.gst_number:
+                    supplier_cust = Customer.objects.filter(
+                        gst_number=business.gst_number
+                    ).first()
+                if supplier_cust is None:
+                    supplier_cust = Customer.objects.filter(
+                        name__iexact=business.name
+                    ).first()
+                if supplier_cust is None:
+                    supplier_cust = Customer.objects.create(
+                        name=business.name[:255],
+                        gst_number=business.gst_number or "",
+                        state_name=(getattr(business, "state_name", "") or "RAJASTHAN")[:255],
+                        workspace_id=1,
+                    )
+                mirror_existing = Invoice.objects.filter(
+                    business=buyer_business,
+                    invoice_number__iexact=inv_number,
+                    invoice_date=inv_date,
+                    type_of_invoice=INVOICE_TYPE_INWARD,
+                ).first()
+                if mirror_existing is not None:
+                    return mirror_existing.id, True
+                mirror = Invoice.objects.create(
+                    customer=supplier_cust,
+                    business=buyer_business,
+                    invoice_number=inv_number,
+                    invoice_date=inv_date,
+                    type_of_invoice=INVOICE_TYPE_INWARD,
+                    total_amount=primary_invoice.total_amount,
+                )
+                for li in LineItem.objects.filter(invoice=primary_invoice):
+                    LineItem.objects.create(
+                        customer=supplier_cust,
+                        invoice=mirror,
+                        product_name=li.product_name,
+                        hsn_code=li.hsn_code,
+                        gst_tax_rate=li.gst_tax_rate,
+                        quantity=li.quantity,
+                        rate=li.rate,
+                        amount=li.amount,
+                        cgst=li.cgst,
+                        sgst=li.sgst,
+                        igst=li.igst,
+                    )
+                mirror.total_amount = primary_invoice.total_amount
+                mirror.save()
+                # Audit image on the mirror too — same physical document.
+                if source_file is not None:
+                    try:
+                        source_file.seek(0)
+                        mirror.source_file.save(
+                            source_file.name, source_file, save=True
+                        )
+                        if primary_invoice.source_preview:
+                            from django.core.files.base import ContentFile
+                            with primary_invoice.source_preview.open("rb") as pf:
+                                mirror.source_preview.save(
+                                    primary_invoice.source_preview.name.rsplit("/", 1)[-1],
+                                    ContentFile(pf.read()),
+                                    save=True,
+                                )
+                    except Exception as e:
+                        logger.warning(
+                            "Could not copy source image to mirror %s: %s",
+                            mirror.pk, e,
+                        )
+                return mirror.id, False
+
             existing = (
                 Invoice.objects.filter(
                     business_id=business_id,
@@ -3431,6 +3558,9 @@ class AIInvoiceCreateView(APIView):
                 ).first()
             )
             if existing is not None:
+                # Primary already exists — still ensure the inter-firm
+                # inward mirror is present (completes half-done pairs).
+                inward_invoice_id, inward_duplicate = ensure_inward_mirror(existing)
                 return Response(
                     {
                         "success": True,
@@ -3440,6 +3570,8 @@ class AIInvoiceCreateView(APIView):
                         "line_items_created": 0,
                         "total_amount": existing.total_amount,
                         "duplicate": True,
+                        "inward_invoice_id": inward_invoice_id,
+                        "inward_duplicate": inward_duplicate,
                         "message": (
                             f"Invoice {inv_number} from {customer.name} on "
                             f"{inv_date} already exists — skipped duplicate."
@@ -3541,6 +3673,10 @@ class AIInvoiceCreateView(APIView):
             )
             invoice.save()
 
+            # Inter-firm: also write the INWARD mirror for the buyer firm
+            # (no-op unless inter_firm was requested).
+            inward_invoice_id, inward_duplicate = ensure_inward_mirror(invoice)
+
             return Response(
                 {
                     "success": True,
@@ -3549,6 +3685,9 @@ class AIInvoiceCreateView(APIView):
                     "customer_name": customer.name,
                     "line_items_created": line_items_created,
                     "total_amount": invoice.total_amount,
+                    # Inter-firm mirror info (null when not inter-firm)
+                    "inward_invoice_id": inward_invoice_id,
+                    "inward_duplicate": inward_duplicate,
                     "message": "Invoice created successfully",
                 }
             )

--- a/sweet-rebuild-suite-main/src/pages/AIInvoiceImport.tsx
+++ b/sweet-rebuild-suite-main/src/pages/AIInvoiceImport.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { useBusinesses } from "@/hooks/useDataStore";
+import { useBusinesses, useCustomers } from "@/hooks/useDataStore";
+import type { Customer } from "@/hooks/useDataStore";
 import Breadcrumbs from "@/components/Breadcrumbs";
 import {
   Upload, Bot, CheckCircle, ArrowRight, Image as ImageIcon, Sparkles,
@@ -67,6 +68,11 @@ type FileEntry = {
   // "Gemini #2/3" so the user can see they're burning through the pool.
   keyIndex: number | null;
   keyTotal: number | null;
+  // Inter-firm: both GSTINs on the bill are our own firms. The create
+  // call writes TWO entries — OUTWARD for the seller (matchedBusiness)
+  // and an INWARD mirror for this buyer firm.
+  interFirm: boolean;
+  interFirmBuyer: { id: number; name: string } | null;
 };
 
 // HEIC/HEIF added for iPhone uploads — backend's pillow-heif decodes
@@ -136,6 +142,8 @@ export default function AIInvoiceImport() {
         expanded: false,
         keyIndex: null,
         keyTotal: null,
+        interFirm: false,
+        interFirmBuyer: null,
       });
     }
     if (accepted.length) {
@@ -176,6 +184,8 @@ export default function AIInvoiceImport() {
         data: Extracted;
         matched_business: MatchedBusiness;
         detected_type: "inward" | "outward" | null;
+        inter_firm?: boolean;
+        inter_firm_buyer_business?: { id: number; name: string; gst_number: string } | null;
         key_index: number | null;
         key_total: number | null;
       }>("ai/invoice/process/", fd, { timeout: 120_000 });
@@ -189,6 +199,10 @@ export default function AIInvoiceImport() {
         type: res.data.detected_type || entry.type,
         keyIndex: res.data.key_index,
         keyTotal: res.data.key_total,
+        interFirm: !!res.data.inter_firm,
+        interFirmBuyer: res.data.inter_firm_buyer_business
+          ? { id: res.data.inter_firm_buyer_business.id, name: res.data.inter_firm_buyer_business.name }
+          : null,
         expanded: true,
       });
     } catch (e: unknown) {
@@ -262,11 +276,19 @@ export default function AIInvoiceImport() {
       fd.append("type_of_invoice", entry.type);
       fd.append("invoice_data", JSON.stringify(entry.extracted));
       fd.append("source_file", entry.file, entry.file.name);
+      // Inter-firm: ask the backend to also write the INWARD mirror
+      // for the buyer firm from this same upload.
+      if (entry.interFirm && entry.interFirmBuyer) {
+        fd.append("inter_firm", "true");
+        fd.append("inter_firm_buyer_business_id", String(entry.interFirmBuyer.id));
+      }
       const res = await api.post<{
         invoice_id: number;
         invoice_number: string;
         line_items_created: number;
         duplicate?: boolean;
+        inward_invoice_id?: number | null;
+        inward_duplicate?: boolean;
       }>("ai/invoice/create/", fd);
       updateFile(entry.id, {
         // Distinguish "we created a new one" from "backend dedup'd to
@@ -275,6 +297,12 @@ export default function AIInvoiceImport() {
         createdInvoiceId: res.data.invoice_id,
         errorMsg: "",
       });
+      if (entry.interFirm && res.data.inward_invoice_id) {
+        toast({
+          title: res.data.inward_duplicate ? "Inter-firm: inward already existed" : "Inter-firm: 2 entries created",
+          description: `${entry.matchedBusiness?.name || "Seller"} outward + ${entry.interFirmBuyer?.name || "buyer"} inward #${res.data.invoice_number}`,
+        });
+      }
       return true;
     } catch (e: unknown) {
       const err = e as { response?: { data?: { error?: string } } };
@@ -585,6 +613,14 @@ function FileCard({ entry, businesses, onRemove, onProcess, onCreate, onUpdate, 
                 Key #{entry.keyIndex}/{entry.keyTotal}
               </span>
             )}
+            {entry.interFirm && (
+              <span
+                className="text-[9px] font-bold uppercase px-1.5 py-0.5 rounded bg-chart-3/15 text-chart-3 tracking-wider shrink-0"
+                title={`Both parties are your firms — creates OUTWARD for ${entry.matchedBusiness?.name} + INWARD for ${entry.interFirmBuyer?.name}`}
+              >
+                Inter-firm ×2
+              </span>
+            )}
           </div>
           <p className="text-[11px] text-muted-foreground">
             {(entry.file.size / 1024 / 1024).toFixed(2)}MB
@@ -680,6 +716,10 @@ function ReviewForm({
 }) {
   const ex = entry.extracted!;
   const [creating, setCreating] = useState(false);
+  // Existing customers for the name autocomplete. Lets the user pick an
+  // existing record (filling GSTIN/address too) instead of free-typing a
+  // name that risks a near-duplicate.
+  const { items: customers } = useCustomers();
 
   const handleCreate = async () => {
     setCreating(true);
@@ -721,6 +761,13 @@ function ReviewForm({
         </div>
         <div className="space-y-1">
           <label className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">Invoice Type</label>
+          {entry.interFirm ? (
+            /* Inter-firm bills produce BOTH entries — direction toggle
+               would be misleading, so show what will happen instead. */
+            <div className="h-9 px-3 rounded-lg bg-chart-3/10 border border-chart-3/25 flex items-center gap-1.5 text-[11px] text-chart-3 font-medium">
+              Inter-firm: Sale ({entry.matchedBusiness?.name?.split(" ")[0]}) + Purchase ({entry.interFirmBuyer?.name?.split(" ")[0]})
+            </div>
+          ) : (
           <div className="flex rounded-lg overflow-hidden border border-border/60 h-9">
             <button
               onClick={() => onUpdate({ type: "outward" })}
@@ -737,6 +784,7 @@ function ReviewForm({
               Purchase
             </button>
           </div>
+          )}
         </div>
       </div>
 
@@ -750,8 +798,21 @@ function ReviewForm({
 
       {/* Customer (supplier for purchase) */}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        <Field label="Customer Name" value={ex.customer_name}
-          onChange={(v) => onUpdateExtracted({ ...ex, customer_name: v })} />
+        <CustomerNameField
+          value={ex.customer_name}
+          customers={customers}
+          onChange={(v) => onUpdateExtracted({ ...ex, customer_name: v })}
+          onPick={(c) => onUpdateExtracted({
+            ...ex,
+            customer_name: c.name,
+            // Fill the related fields from the chosen record — but never
+            // clobber a value the AI already extracted with a blank.
+            customer_gst_number: c.gst_number || ex.customer_gst_number,
+            customer_address: c.address || ex.customer_address,
+            customer_pan_number: c.pan_number || ex.customer_pan_number,
+            customer_mobile_number: c.mobile_number || ex.customer_mobile_number,
+          })}
+        />
         <Field label="GSTIN" value={ex.customer_gst_number}
           onChange={(v) => onUpdateExtracted({ ...ex, customer_gst_number: v })} />
       </div>
@@ -846,6 +907,97 @@ function Field({ label, value, onChange, type = "text" }: {
         onChange={(e) => onChange(e.target.value)}
         className="premium-input h-9 w-full text-[12px]"
       />
+    </div>
+  );
+}
+
+// Customer name field with a type-ahead dropdown of existing customers.
+// Picking one fills the related fields (GSTIN/address/etc.) so the user
+// links to an existing record instead of free-typing a near-duplicate.
+// Free text is still allowed — typing a brand-new name just creates a
+// new customer on import, same as before.
+function CustomerNameField({ value, customers, onChange, onPick }: {
+  value: string;
+  customers: Customer[];
+  onChange: (name: string) => void;
+  onPick: (c: Customer) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState(0);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  // Filter by substring; prefix matches rank first. Cap at 8 so the list
+  // stays scannable even with hundreds of customers.
+  const matches = useMemo(() => {
+    const q = (value || "").toLowerCase().trim();
+    if (!q) return customers.slice(0, 8);
+    const scored = customers
+      .filter((c) => c.name.toLowerCase().includes(q))
+      .sort((a, b) => {
+        const ap = a.name.toLowerCase().startsWith(q) ? 0 : 1;
+        const bp = b.name.toLowerCase().startsWith(q) ? 0 : 1;
+        return ap - bp || a.name.localeCompare(b.name);
+      });
+    return scored.slice(0, 8);
+  }, [value, customers]);
+
+  // Close on outside click.
+  useEffect(() => {
+    const h = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", h);
+    return () => document.removeEventListener("mousedown", h);
+  }, []);
+
+  // Exact-match indicator so the user knows when their typed name already
+  // resolves to an existing customer (no new record will be created).
+  const exact = customers.find((c) => c.name.toLowerCase().trim() === (value || "").toLowerCase().trim());
+
+  return (
+    <div className="space-y-1" ref={wrapRef}>
+      <label className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+        Customer Name
+        {exact ? <span className="text-success normal-case font-normal ml-1">· existing</span>
+               : (value || "").trim() ? <span className="text-warning normal-case font-normal ml-1">· new</span> : null}
+      </label>
+      <div className="relative">
+        <input
+          type="text"
+          value={value || ""}
+          onChange={(e) => { onChange(e.target.value); setOpen(true); setActive(0); }}
+          onFocus={() => setOpen(true)}
+          onKeyDown={(e) => {
+            if (!open || matches.length === 0) return;
+            if (e.key === "ArrowDown") { e.preventDefault(); setActive((i) => Math.min(i + 1, matches.length - 1)); }
+            else if (e.key === "ArrowUp") { e.preventDefault(); setActive((i) => Math.max(i - 1, 0)); }
+            else if (e.key === "Enter") { e.preventDefault(); onPick(matches[active]); setOpen(false); }
+            else if (e.key === "Escape") { setOpen(false); }
+          }}
+          placeholder="Search or type a name…"
+          className="premium-input h-9 w-full text-[12px]"
+          autoComplete="off"
+        />
+        {open && matches.length > 0 && (
+          <div className="absolute z-50 left-0 right-0 mt-1 max-h-56 overflow-auto rounded-lg border border-border/60 bg-popover shadow-lg">
+            {matches.map((c, i) => (
+              <button
+                key={c.id}
+                type="button"
+                onMouseEnter={() => setActive(i)}
+                onClick={() => { onPick(c); setOpen(false); }}
+                className={cn(
+                  "w-full text-left px-3 py-2 flex items-center justify-between gap-2 transition-colors",
+                  i === active ? "bg-accent/40" : "hover:bg-accent/25"
+                )}
+              >
+                <span className="text-[12px] text-foreground truncate">{c.name}</span>
+                {c.gst_number && <span className="text-[10px] font-mono text-muted-foreground shrink-0">{c.gst_number}</span>}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/sweet-rebuild-suite-main/src/pages/ImportReview.tsx
+++ b/sweet-rebuild-suite-main/src/pages/ImportReview.tsx
@@ -512,6 +512,7 @@ export default function ImportReview() {
                 <th className="px-3 py-2.5 text-left font-semibold text-muted-foreground">GST</th>
                 <th className="px-3 py-2.5 text-left font-semibold text-muted-foreground">Firm</th>
                 <th className="px-3 py-2.5 text-center font-semibold text-muted-foreground">Items</th>
+                <th className="px-3 py-2.5 text-right font-semibold text-muted-foreground whitespace-nowrap">Rate</th>
                 <th className="px-3 py-2.5 text-center font-semibold text-muted-foreground whitespace-nowrap">GST&nbsp;%</th>
                 <th className="px-3 py-2.5 text-right font-semibold text-muted-foreground">Taxable</th>
                 <th className="px-3 py-2.5 text-right font-semibold text-muted-foreground">CGST</th>
@@ -597,6 +598,22 @@ export default function ImportReview() {
                         <>{inv.items.length}<span className="text-[9px] text-muted-foreground ml-0.5">({inv.items.map(i => `${i.qty}${i.unit || "gms"}`).join(", ")})</span></>
                       )}
                     </td>
+                    {/* Rate (₹ per unit). In edit mode the value is edited
+                        in the Items cell above (qty @ rate); here we mirror
+                        the live value muted so the column stays populated. */}
+                    <td className="px-3 py-2 text-right tabular-nums font-mono text-[11px] text-muted-foreground whitespace-nowrap">
+                      {editingIdx === idx ? (
+                        <span className="opacity-70">{"₹"}{editForm.rate || 0}</span>
+                      ) : (() => {
+                        const rates = Array.from(new Set(inv.items.map(i => i.rate))).filter(r => r > 0);
+                        if (rates.length === 0) return <span className="text-muted-foreground/50">-</span>;
+                        const units = Array.from(new Set(inv.items.map(i => i.unit || "gms")));
+                        const suffix = units.length === 1 ? `/${units[0]}` : "";
+                        return rates.length === 1
+                          ? <>{"₹"}{fmt(rates[0])}<span className="text-[9px] opacity-50">{suffix}</span></>
+                          : rates.map(r => `${"₹"}${fmt(r)}`).join(" / ");
+                      })()}
+                    </td>
                     <td className="px-3 py-2 text-center font-mono text-muted-foreground text-[11px]">
                       {(() => {
                         const rates = Array.from(new Set(inv.items.map(i => i.gstRate))).filter(r => r > 0);
@@ -625,7 +642,7 @@ export default function ImportReview() {
             </tbody>
             <tfoot className="bg-secondary/40 border-t-2 border-border/40">
               <tr className="font-semibold text-[11px]">
-                <td colSpan={9} className="px-3 py-2.5 text-right text-muted-foreground uppercase">
+                <td colSpan={10} className="px-3 py-2.5 text-right text-muted-foreground uppercase">
                   Selected Total ({selectedInvoices.size} invoices)
                 </td>
                 <td className="px-3 py-2.5 text-right tabular-nums">{"\u20b9"}{fmt(selectedResults.reduce((s, v) => s + v.invoice.subtotal, 0))}</td>

--- a/sweet-rebuild-suite-main/src/pages/ImportReview.tsx
+++ b/sweet-rebuild-suite-main/src/pages/ImportReview.tsx
@@ -87,26 +87,64 @@ function normalizeName(s: string): string {
     .trim();
 }
 
+// Two tokens "match" when one is a clear truncation of the other —
+// e.g. "jew" → "jewellers", "ent" → "enterprises". The 3-char floor
+// stops trivially-short prefixes ("a"→"anything") from matching.
+function isPrefixAbbrev(x: string, y: string): boolean {
+  const [shortT, longT] = x.length <= y.length ? [x, y] : [y, x];
+  return shortT.length >= 3 && longT.startsWith(shortT) && shortT !== longT;
+}
+
+// Token-aligned score: the precise matcher for this domain. Requires the
+// SAME token count (after honorific stripping) and that every aligned
+// token pair is identical, a fuzzy near-match (≥0.7), or a prefix
+// abbreviation. ANY failing token kills the match outright.
+//
+// This is what catches the abbreviation case "DARSHAN JEW." ↔ "DARSHAN
+// JEWELLERS" (Levenshtein ratio alone scored it 0.75, just under the
+// bar, because it penalises the dropped "ELLERS"). It's also stricter
+// than the blended score on false positives: different token COUNT or
+// any sub-0.7 token returns 0, so "DARSHAN JEWELLERS"↔"KRISHNA
+// JEWELLERS" (darshan/krishna ≈0.29) and "RAMLAL DANGI"↔"RAMLAL JI"
+// (1 token vs 2 after stripping "ji") both fail cleanly.
+function tokenAlignScore(imp: string, cust: string): number {
+  const a = normalizeName(imp).split(" ").filter(Boolean);
+  const b = normalizeName(cust).split(" ").filter(Boolean);
+  if (a.length === 0 || b.length === 0) return 0;
+  if (a.length !== b.length) return 0;
+  let sum = 0;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] === b[i]) { sum += 1; continue; }
+    if (isPrefixAbbrev(a[i], b[i])) { sum += 0.9; continue; }
+    const r = ratio(a[i], b[i]);
+    if (r < 0.7) return 0; // one mismatched token ⇒ different entity
+    sum += r;
+  }
+  return sum / a.length;
+}
+
+// Blended Levenshtein score — handles same-length typos/transliteration
+// where token-align might be slightly off. First-token gate guards
+// against shared-suffix false positives.
+function blendedScore(imp: string, cust: string): number {
+  const a = normalizeName(imp), b = normalizeName(cust);
+  if (!a || !b) return 0;
+  if (a === b) return 1;
+  const aFirst = a.split(" ")[0] || "";
+  const bFirst = b.split(" ")[0] || "";
+  const firstTok = ratio(aFirst, bFirst);
+  if (firstTok < 0.6) return 0;
+  return ratio(a, b) * 0.7 + firstTok * 0.3;
+}
+
 // Returns a 0..1 confidence that `imp` and `cust` are the same entity.
-// Combines overall similarity with first-token similarity; the latter
-// is the guard against shared-suffix false positives.
+// Max of the two scorers — both independently reject the false
+// positives, so taking the max only ever helps recall.
 function nameMatchScore(imp: string, cust: string): number {
   const a = normalizeName(imp), b = normalizeName(cust);
   if (!a || !b) return 0;
   if (a === b) return 1;
-  const overall = ratio(a, b);
-  const aFirst = a.split(" ")[0] || "";
-  const bFirst = b.split(" ")[0] || "";
-  const firstTok = ratio(aFirst, bFirst);
-  // Gate: a weak first-token match can't produce a suggestion even if
-  // the suffix matches perfectly. 0.6 cleanly separates real variants
-  // (satyanaryan/satyanarayan ≈0.9, gordhanlal/goverdhanlal ≈0.83) from
-  // false positives (darshan/krishna ≈0.29, ramlal/gahrilal ≈0.38).
-  if (firstTok < 0.6) return 0;
-  // Blend: overall similarity carries the decision, first-token acts as
-  // a confidence multiplier so a same-first-name-different-surname pair
-  // still needs decent overall similarity to surface.
-  return overall * 0.7 + firstTok * 0.3;
+  return Math.max(tokenAlignScore(imp, cust), blendedScore(imp, cust));
 }
 
 const SUGGEST_THRESHOLD = 0.78;

--- a/sweet-rebuild-suite-main/src/pages/ImportReview.tsx
+++ b/sweet-rebuild-suite-main/src/pages/ImportReview.tsx
@@ -36,6 +36,81 @@ function fmt(n: number) {
   return new Intl.NumberFormat("en-IN", { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(n);
 }
 
+// ─── Fuzzy customer-name matching (suggest-only) ───────────────────────
+// Indian jewellery customer names have lots of transliteration variants
+// and typos: CHARBHUJA JEWLLERS↔JEWELLERS, KISHANLAL CHHOGALAL↔CHOGALAL,
+// SATYANARYAN↔SATYANARAYAN, plus "JI" honorifics. Exact match misses all
+// of these and flags them as new customers — creating duplicate ledgers.
+//
+// But naive fuzzy matching is DANGEROUS here: "DARSHAN JEWELLERS" and
+// "KRISHNA JEWELLERS" share the " JEWELLERS" suffix and score ~0.7
+// overall despite being different shops; "RAMLAL DANGI" and "GAHRILAL
+// DANGI" are different people sharing the "DANGI" surname. Auto-merging
+// those corrupts GST records by attributing sales to the wrong party.
+//
+// Defense: require the FIRST token (the distinctive part — given name or
+// shop name) to be similar, not just the whole string. The shared suffix
+// can't carry a false match on its own. And we only ever SUGGEST — the
+// user clicks to adopt, never silent.
+
+function levenshtein(a: string, b: string): number {
+  const m = a.length, n = b.length;
+  if (m === 0) return n;
+  if (n === 0) return m;
+  let prev = Array.from({ length: n + 1 }, (_, i) => i);
+  let cur = new Array(n + 1).fill(0);
+  for (let i = 1; i <= m; i++) {
+    cur[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      cur[j] = Math.min(cur[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost);
+    }
+    [prev, cur] = [cur, prev];
+  }
+  return prev[n];
+}
+
+function ratio(a: string, b: string): number {
+  if (!a || !b) return 0;
+  if (a === b) return 1;
+  return 1 - levenshtein(a, b) / Math.max(a.length, b.length);
+}
+
+// Strip the common honorifics/suffixes that inflate or deflate the
+// comparison without changing identity. "JI", "SHRI", "SMT" etc.
+function normalizeName(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/\b(ji|shri|sri|smt|shree|m\/s|messrs)\b/g, " ")
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+// Returns a 0..1 confidence that `imp` and `cust` are the same entity.
+// Combines overall similarity with first-token similarity; the latter
+// is the guard against shared-suffix false positives.
+function nameMatchScore(imp: string, cust: string): number {
+  const a = normalizeName(imp), b = normalizeName(cust);
+  if (!a || !b) return 0;
+  if (a === b) return 1;
+  const overall = ratio(a, b);
+  const aFirst = a.split(" ")[0] || "";
+  const bFirst = b.split(" ")[0] || "";
+  const firstTok = ratio(aFirst, bFirst);
+  // Gate: a weak first-token match can't produce a suggestion even if
+  // the suffix matches perfectly. 0.6 cleanly separates real variants
+  // (satyanaryan/satyanarayan ≈0.9, gordhanlal/goverdhanlal ≈0.83) from
+  // false positives (darshan/krishna ≈0.29, ramlal/gahrilal ≈0.38).
+  if (firstTok < 0.6) return 0;
+  // Blend: overall similarity carries the decision, first-token acts as
+  // a confidence multiplier so a same-first-name-different-surname pair
+  // still needs decent overall similarity to surface.
+  return overall * 0.7 + firstTok * 0.3;
+}
+
+const SUGGEST_THRESHOLD = 0.78;
+
 export default function ImportReview() {
   const location = useLocation();
   const navigate = useNavigate();
@@ -53,6 +128,9 @@ export default function ImportReview() {
   const [editForm, setEditForm] = useState({ date: "", party: "", gst: "", qty: "", rate: "" });
   const [newlyCreatedCustomers, setNewlyCreatedCustomers] = useState<string[]>([]);
   const [bizFilter] = useState(state?.bizFilter || "all");
+  // Bumped when a fuzzy suggestion is adopted (mutates excelPreview in
+  // place) — forces the validation memo to recompute against the new name.
+  const [adoptTick, setAdoptTick] = useState(0);
 
   // Redirect if no data
   if (!state?.parsedInvoices || state.parsedInvoices.length === 0) {
@@ -117,12 +195,53 @@ export default function ImportReview() {
 
       return { invoice: inv, businessMatch, customerMatch, isDuplicate, status };
     });
-  }, [excelPreview, businesses, customers, existingInvoices, bizFilter, customerNameMap, newlyCreatedCustomers]);
+    // adoptTick: excelPreview rows are mutated in place when a suggestion
+    // is adopted, so the reference doesn't change — the tick forces recompute.
+  }, [excelPreview, businesses, customers, existingInvoices, bizFilter, customerNameMap, newlyCreatedCustomers, adoptTick]);
 
   const readyCount = validationResults.filter(v => v.status === "ready").length;
   const missingCustCount = validationResults.filter(v => v.status === "missing_customer").length;
   const duplicateCount = validationResults.filter(v => v.status === "duplicate").length;
   const missingBizCount = validationResults.filter(v => v.status === "missing_business").length;
+
+  // Fuzzy suggestions for "New Customer" rows — best existing customer
+  // above the confidence threshold. Suggest-only: the user clicks to
+  // adopt (adoptSuggestion below). Keyed by the row's excelPreview index.
+  const suggestionByIdx = useMemo(() => {
+    const out = new Map<number, { customer: Customer; score: number }>();
+    if (customers.length === 0) return out;
+    validationResults.forEach((v, idx) => {
+      if (v.status !== "missing_customer") return;
+      const imp = v.invoice.customerName || "";
+      if (!imp.trim()) return;
+      let best: { customer: Customer; score: number } | null = null;
+      for (const c of customers) {
+        const s = nameMatchScore(imp, c.name);
+        if (s >= SUGGEST_THRESHOLD && (!best || s > best.score)) {
+          best = { customer: c, score: s };
+        }
+      }
+      if (best) out.set(idx, best);
+    });
+    return out;
+  }, [validationResults, customers]);
+
+  const suggestionCount = suggestionByIdx.size;
+
+  // Adopt a suggested customer: rewrite the row's party name (and GST if
+  // we have one and the row lacks it) to the canonical DB customer, so
+  // the backend's exact-name match links it instead of creating a new
+  // one. Mutates excelPreview in place (same pattern as saveEditing) and
+  // bumps a counter to force the validation memo to recompute.
+  const adoptSuggestion = (idx: number, customer: Customer) => {
+    const inv = excelPreview[idx];
+    if (!inv) return;
+    inv.customerName = customer.name;
+    const gst = (customer as any).gst_number;
+    if (gst && (!inv.customerGST || inv.customerGST === "-")) inv.customerGST = gst;
+    setAdoptTick(t => t + 1);
+    toast({ title: "Customer matched", description: `Linked to ${customer.name}` });
+  };
 
   // Auto-select importable
   useEffect(() => {
@@ -350,6 +469,28 @@ export default function ImportReview() {
             Invoices ({validationResults.length})
           </h2>
           <div className="flex items-center gap-3">
+            {suggestionCount > 0 && (
+              <button
+                onClick={() => {
+                  // Snapshot first — adopting mutates excelPreview, which
+                  // would shrink suggestionByIdx mid-iteration.
+                  const toAdopt = Array.from(suggestionByIdx.entries());
+                  toAdopt.forEach(([idx, sug]) => {
+                    const inv = excelPreview[idx];
+                    if (!inv) return;
+                    inv.customerName = sug.customer.name;
+                    const gst = (sug.customer as any).gst_number;
+                    if (gst && (!inv.customerGST || inv.customerGST === "-")) inv.customerGST = gst;
+                  });
+                  setAdoptTick(t => t + 1);
+                  toast({ title: "Suggestions applied", description: `${toAdopt.length} customer${toAdopt.length === 1 ? "" : "s"} linked to existing records.` });
+                }}
+                className="inline-flex items-center gap-1 rounded-md bg-blue-500/10 hover:bg-blue-500/20 border border-blue-500/30 px-2 py-1 text-[11px] text-blue-400 font-medium transition-colors"
+                title="Link all near-match names to their suggested existing customers"
+              >
+                <Check className="w-3 h-3" /> Match all {suggestionCount} suggestion{suggestionCount === 1 ? "" : "s"}
+              </button>
+            )}
             <span className="text-[11px] text-muted-foreground">{selectedInvoices.size} selected</span>
             <button onClick={toggleAll} className="text-[11px] text-primary hover:underline font-medium">
               {selectedInvoices.size === (readyCount + missingCustCount) ? "Deselect All" : "Select All"}
@@ -408,11 +549,33 @@ export default function ImportReview() {
                         : inv.invoice_date
                       }
                     </td>
-                    <td className="px-3 py-2 max-w-[160px] truncate" title={inv.customerName}>
-                      {editingIdx === idx
-                        ? <input type="text" value={editForm.party} onChange={e => setEditForm(p => ({ ...p, party: e.target.value }))} className="w-full px-1.5 py-1 rounded bg-input border border-border text-[11px]" />
-                        : <>{inv.customerName}{v.customerMatch && <span className="text-[9px] text-success ml-1">(matched)</span>}</>
-                      }
+                    <td className="px-3 py-2 max-w-[200px]" title={inv.customerName}>
+                      {editingIdx === idx ? (
+                        <input type="text" value={editForm.party} onChange={e => setEditForm(p => ({ ...p, party: e.target.value }))} className="w-full px-1.5 py-1 rounded bg-input border border-border text-[11px]" />
+                      ) : (
+                        <div className="flex flex-col gap-0.5">
+                          <span className="truncate">{inv.customerName}{v.customerMatch && <span className="text-[9px] text-success ml-1">(matched)</span>}</span>
+                          {/* Fuzzy suggestion chip — only on unmatched rows.
+                              One click rewrites the name to the canonical DB
+                              customer so the backend links instead of dupes. */}
+                          {(() => {
+                            const sug = suggestionByIdx.get(idx);
+                            if (!sug || v.status !== "missing_customer") return null;
+                            const pct = Math.round(sug.score * 100);
+                            return (
+                              <button
+                                onClick={() => adoptSuggestion(idx, sug.customer)}
+                                className="inline-flex items-center gap-1 self-start rounded-md bg-blue-500/10 hover:bg-blue-500/20 border border-blue-500/30 px-1.5 py-0.5 text-[9px] text-blue-400 transition-colors"
+                                title={`Use existing customer "${sug.customer.name}" (${pct}% match)`}
+                              >
+                                <Check className="w-2.5 h-2.5" />
+                                <span className="truncate max-w-[130px]">≈ {sug.customer.name}</span>
+                                <span className="opacity-60">{pct}%</span>
+                              </button>
+                            );
+                          })()}
+                        </div>
+                      )}
                     </td>
                     <td className="px-3 py-2 font-mono text-[10px] max-w-[110px] truncate" title={inv.customerGST}>
                       {editingIdx === idx


### PR DESCRIPTION
34 commits from a rolling session. Started as admin-page polish, grew into a substantial AI Import + import-tooling epic.

## 1. AI Invoice Import (new feature, end-to-end)
Drop invoice photos → AI extracts → review → create. Google Gemini 2.5 Flash-Lite with **multi-key rotation** (N keys × 20/day free-tier), bulk upload, **HEIC** (iPhone) support, 20MB cap, **auto-process on drop**, 4-way concurrent.
- **Business + direction auto-detected** from buyer/seller GSTINs; customer auto-created + DB-backfilled (GSTIN/address/PAN/mobile)
- **Inter-firm bills**: when both parties are your own firms, one upload creates BOTH the OUTWARD (sale) and INWARD (purchase/ITC) entries, each dedup'd independently
- Source image + browser-safe JPEG preview saved per invoice (audit trail)
- Idempotent dedup on (business, customer, invoice#, date); correct CGST/SGST/IGST computed per line
- Customer-name type-ahead on the review form (pick existing → fills GSTIN)

## 2. GSTR-2A bulk import (service + management command)
`python manage.py import_gstr2a [--dry-run] <files>` — parses xls/xlsx, **auto-nets credit notes**, multi-state customer disambiguation, fully idempotent.

## 3. Excel import review polish
- **Fuzzy customer suggestions** (suggest-only, first-token-gated to avoid false merges like Darshan↔Krishna Jewellers) + abbreviation matching (DARSHAN JEW. ↔ JEWELLERS)
- **Rate (₹/unit) column** added to the review table

## 4. Invoice detail
FROM/TO now direction-aware (INWARD shows supplier→us); source-image card with preview + download.

## 5. UX polish + CI
Admin pages (Settings dirty-save, Backup, Audit Log, User Mgmt), Profile, command-palette legibility, mobile audit, consistency sweep. CI: all Python pins aligned on 3.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)