### PR TITLE
security: login throttling, SECRET_KEY guard, SPA compression/caching

### DIFF
--- a/billing/api/auth.py
+++ b/billing/api/auth.py
@@ -1,0 +1,41 @@
+"""Throttled JWT endpoints.
+
+The token endpoints are the only unauthenticated POST surface, and production
+had no throttling at all — three rapid wrong-password attempts were accepted
+without so much as a header (verified live, 19 Aug 2026). Scoped rates keyed
+by client IP; in production the throttle state lives in Redis (shared across
+gunicorn workers), locally in locmem (per-process, still effective for a
+single runserver).
+"""
+
+from rest_framework.settings import api_settings
+from rest_framework.throttling import ScopedRateThrottle
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+
+from .serializers import CustomTokenObtainPairSerializer
+
+
+class DynamicScopedRateThrottle(ScopedRateThrottle):
+    """ScopedRateThrottle that reads its rates at request time.
+
+    SimpleRateThrottle binds THROTTLE_RATES = api_settings.DEFAULT_THROTTLE_RATES
+    as a class attribute when rest_framework.throttling is first imported, so a
+    settings change after that (override_settings in tests, any runtime reload)
+    is invisible to it — which made the throttle tests pass or fail depending
+    on which test file imported DRF first. A property makes the lookup live.
+    """
+
+    @property
+    def THROTTLE_RATES(self):
+        return api_settings.DEFAULT_THROTTLE_RATES
+
+
+class ThrottledTokenObtainPairView(TokenObtainPairView):
+    serializer_class = CustomTokenObtainPairSerializer
+    throttle_classes = [DynamicScopedRateThrottle]
+    throttle_scope = "login"
+
+
+class ThrottledTokenRefreshView(TokenRefreshView):
+    throttle_classes = [DynamicScopedRateThrottle]
+    throttle_scope = "token_refresh"

--- a/billing/api/urls.py
+++ b/billing/api/urls.py
@@ -1,11 +1,8 @@
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
-from rest_framework_simplejwt.views import (
-    TokenObtainPairView,
-    TokenRefreshView,
-    TokenVerifyView,
-)
-from .serializers import CustomTokenObtainPairSerializer
+from rest_framework_simplejwt.views import TokenVerifyView
+
+from .auth import ThrottledTokenObtainPairView, ThrottledTokenRefreshView
 
 from .inward_bills import (
     InwardBillDetailView,
@@ -68,7 +65,7 @@ urlpatterns = [
     path("profile/", ProfileView.as_view(), name="profile"),
     path("users/", UserManagementView.as_view(), name="user-management"),
     # JWT Authentication endpoints
-    path("token/", TokenObtainPairView.as_view(serializer_class=CustomTokenObtainPairSerializer), name="token_obtain_pair"),
-    path("token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
+    path("token/", ThrottledTokenObtainPairView.as_view(), name="token_obtain_pair"),
+    path("token/refresh/", ThrottledTokenRefreshView.as_view(), name="token_refresh"),
     path("token/verify/", TokenVerifyView.as_view(), name="token_verify"),
 ]

--- a/billing/tests/test_login_throttle.py
+++ b/billing/tests/test_login_throttle.py
@@ -1,0 +1,58 @@
+"""The token endpoints must rate-limit — they are the only unauthenticated
+POST surface, and production ran without any throttle until 19 Aug 2026."""
+
+from django.core.cache import cache
+from django.test import override_settings
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from billing.tests.test_base import BaseAPITestCase
+
+TIGHT = {
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework_simplejwt.authentication.JWTAuthentication",
+    ],
+    "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
+    "DEFAULT_THROTTLE_CLASSES": [],
+    "DEFAULT_THROTTLE_RATES": {"login": "3/min", "token_refresh": "3/min"},
+}
+
+
+class LoginThrottleTest(BaseAPITestCase):
+    def setUp(self):
+        super().setUp()
+        cache.clear()          # throttle history lives in the cache
+        self.anon = APIClient()
+
+    def tearDown(self):
+        cache.clear()
+        super().tearDown()
+
+    @override_settings(REST_FRAMEWORK=TIGHT)
+    def test_login_throttles_after_the_configured_rate(self):
+        url = reverse("token_obtain_pair")
+        for i in range(3):
+            resp = self.anon.post(url, {"username": "nobody", "password": "wrong"})
+            self.assertEqual(resp.status_code, 401, f"attempt {i+1}")
+        resp = self.anon.post(url, {"username": "nobody", "password": "wrong"})
+        self.assertEqual(resp.status_code, 429)
+        self.assertIn("Retry-After", resp.headers)
+
+    @override_settings(REST_FRAMEWORK=TIGHT)
+    def test_valid_login_inside_the_limit_still_works(self):
+        resp = self.anon.post(reverse("token_obtain_pair"),
+                              {"username": "testuser", "password": "testpassword"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("access", resp.data)
+
+    @override_settings(REST_FRAMEWORK=TIGHT)
+    def test_refresh_throttles_independently(self):
+        login = self.anon.post(reverse("token_obtain_pair"),
+                               {"username": "testuser", "password": "testpassword"})
+        refresh = login.data["refresh"]
+        url = reverse("token_refresh")
+        cache.clear()          # spend the whole budget on refresh alone
+        seen = []
+        for _ in range(4):
+            seen.append(self.anon.post(url, {"refresh": refresh}).status_code)
+        self.assertEqual(seen[-1], 429, seen)

--- a/gst_billing/production_settings.py
+++ b/gst_billing/production_settings.py
@@ -11,7 +11,15 @@ from pathlib import Path
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "insecure-key-for-dev-only")
+SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY")
+if not SECRET_KEY:
+    # This used to fall back to a string that is committed to a public repo —
+    # which also signs every JWT. A missing env var must stop the boot, not
+    # silently run with a known key.
+    raise RuntimeError(
+        "DJANGO_SECRET_KEY is not set. Refusing to start production with a "
+        "known default key."
+    )
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get("DEBUG", "False") == "True"
@@ -23,7 +31,6 @@ CSRF_TRUSTED_ORIGINS = [
     "http://billing.cheq.dpdns.org",
 ]
 
-print(f"DEBUG: {DEBUG}, ALLOWED_HOSTS: {ALLOWED_HOSTS}")
 
 # Application definition
 INSTALLED_APPS = [
@@ -147,6 +154,13 @@ REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAuthenticated",
     ],
+    # Production previously had NO throttling — the login endpoint accepted
+    # unlimited password attempts (verified live 19 Aug 2026). With REDIS_HOST
+    # set (prod compose), throttle state is shared across all gunicorn workers.
+    "DEFAULT_THROTTLE_RATES": {
+        "login": "10/min",
+        "token_refresh": "60/min",
+    },
 }
 
 # JWT settings
@@ -283,12 +297,12 @@ LOGGING = {
     },
     "handlers": {
         "console": {
-            "level": "DEBUG",
+            "level": "INFO",
             "class": "logging.StreamHandler",
             "formatter": "verbose",
         },
         "file": {
-            "level": "DEBUG",
+            "level": "INFO",
             "class": "logging.FileHandler",
             "filename": os.path.join(BASE_DIR, "logs/django.log"),
             "formatter": "verbose",
@@ -312,7 +326,7 @@ LOGGING = {
         },
         "billing": {
             "handlers": ["console", "file"],
-            "level": "DEBUG",
+            "level": "INFO",
             "propagate": False,
         },
     },

--- a/gst_billing/settings.py
+++ b/gst_billing/settings.py
@@ -212,7 +212,15 @@ REST_FRAMEWORK = {
         "rest_framework.throttling.AnonRateThrottle",
         "rest_framework.throttling.UserRateThrottle",
     ],
-    "DEFAULT_THROTTLE_RATES": {"anon": "100/day", "user": "1000/day"},
+    "DEFAULT_THROTTLE_RATES": {
+        "anon": "100/day",
+        "user": "1000/day",
+        # Scoped rates for the unauthenticated token endpoints (billing.api.auth).
+        # 10 login attempts/min per IP stops naive brute force without ever
+        # touching a human; refresh is authenticated-adjacent and more frequent.
+        "login": "10/min",
+        "token_refresh": "60/min",
+    },
     "DEFAULT_RENDERER_CLASSES": (
         [
             "rest_framework.renderers.JSONRenderer",

--- a/gst_billing/test_settings.py
+++ b/gst_billing/test_settings.py
@@ -19,4 +19,13 @@ PASSWORD_HASHERS = [
 
 # Disable throttling for tests
 REST_FRAMEWORK["DEFAULT_THROTTLE_CLASSES"] = []
-REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"] = {}
+# Scoped throttles on the token views instantiate ScopedRateThrottle at the
+# view level (bypassing DEFAULT_THROTTLE_CLASSES), and a missing scope rate
+# raises ImproperlyConfigured — so give every scope a rate too high to ever
+# trip in tests. The throttle test overrides these to a tight rate itself.
+REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"] = {
+    "anon": "10000/min",
+    "user": "10000/min",
+    "login": "10000/min",
+    "token_refresh": "10000/min",
+}

--- a/nginx/conf.d/app.conf
+++ b/nginx/conf.d/app.conf
@@ -7,6 +7,16 @@ map $http_x_forwarded_proto $forwarded_proto {
     ""      $scheme;
 }
 
+# Compression — the main SPA bundle measured 464 KB served raw (no
+# content-encoding, verified live 19 Aug 2026); it gzips to ~150 KB. conf.d
+# files are included in the http context, so this covers every location below.
+gzip on;
+gzip_vary on;
+gzip_comp_level 6;
+gzip_min_length 1024;
+gzip_proxied any;
+gzip_types text/css application/javascript application/json image/svg+xml text/plain application/xml;
+
 server {
     listen 80;
     server_name billing.cheq.dpdns.org;
@@ -57,10 +67,20 @@ server {
         proxy_set_header X-Forwarded-Proto $forwarded_proto;
     }
 
-    # React Frontend
+    # Vite build assets carry a content hash in the filename, so they are
+    # immutable by construction — cache them for a year. index.html must stay
+    # no-cache or a deploy would not propagate until users hard-refresh.
+    location /assets/ {
+        root /usr/share/nginx/html;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # React Frontend (index.html + the SPA fallback for client routes)
     location / {
         root /usr/share/nginx/html;
         try_files $uri $uri/ /index.html;
+        add_header Cache-Control "no-cache";
     }
 }
 


### PR DESCRIPTION
Three gaps found by live probes against production on 19 Aug, plus one ops nit:

1. **Unthrottled login.** `/api/token/` took three rapid wrong-password posts with no rate limit (prod REST_FRAMEWORK had no throttle config at all). Now 10/min login, 60/min refresh, per IP, Redis-shared across workers in prod. Includes a fix for DRF's import-time `THROTTLE_RATES` binding so rates are read live. Verified against a running server: 10× 401 → 429.
2. **SECRET_KEY silent fallback.** Prod ran `os.environ.get(..., "insecure-key-for-dev-only")` — a public-repo string that also signs the JWTs. Now refuses to boot without the env var (which the host `.env` already sets).
3. **464 KB uncompressed, uncacheable SPA.** Measured live: no `content-encoding`, no `cache-control` on `/assets/`. nginx now gzips and serves hashed assets as immutable-1y; `index.html` stays no-cache. Note: CI's E2E runs against Vite, not nginx, so this config is review-verified only.
4. Prod file logging DEBUG→INFO (it grows unbounded inside the container), boot print removed.

138 backend tests green (3 new). No frontend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)