### PR TITLE
ux: IGST read-out chip, month-true Easy GST tile, palette + scroll affordances

### DIFF
--- a/billing/api/views.py
+++ b/billing/api/views.py
@@ -1298,6 +1298,21 @@ class InvoiceViewSet(AuditLogMixin, viewsets.ModelViewSet):
             "inward_tax": float(totals["inward_tax"]),
             "count": totals["count"],
         }
+        # Per-month output tax, aggregated on LineItem directly — joining the
+        # tax into monthly_raw's invoice-level query would re-introduce the
+        # row-multiplication bug fixed in `totals` above. The Easy-mode GST
+        # tile needs this to show a real month instead of FY totals.
+        monthly_tax = {
+            (t["y"], t["m"]): float(t["tax"] or 0)
+            for t in LineItem.objects.filter(
+                invoice_id__in=queryset.values("id"),
+                invoice__type_of_invoice="outward",
+            )
+            .annotate(m=ExtractMonth("invoice__invoice_date"),
+                      y=ExtractYear("invoice__invoice_date"))
+            .values("y", "m")
+            .annotate(tax=Sum(F("cgst") + F("sgst") + F("igst")))
+        }
         results["monthly"] = [
             {
                 "month": m["month"],
@@ -1306,6 +1321,7 @@ class InvoiceViewSet(AuditLogMixin, viewsets.ModelViewSet):
                 "inward_total": float(m["inward_total"]),
                 "outward_count": m["outward_count"],
                 "inward_count": m["inward_count"],
+                "outward_tax": monthly_tax.get((m["year"], m["month"]), 0.0),
             }
             for m in monthly_raw
         ]

--- a/billing/tests/test_dashboard_stats.py
+++ b/billing/tests/test_dashboard_stats.py
@@ -129,3 +129,43 @@ class TopProductsGroupingTest(BaseAPITestCase):
         self._line(inv, "Anklet Pair", "711311", 3, 500, unit="pcs")
         row = [r for r in self._top() if r["name"] == "Anklet Pair"][0]
         self.assertEqual(row["unit"], "pcs")
+
+
+class MonthlyTaxTest(BaseAPITestCase):
+    """The monthly rollup must carry per-month output tax, summed on LineItem
+    directly — a 2-line invoice counts once, and only its own month."""
+
+    def _mk(self, number, lines):
+        inv = Invoice.objects.create(
+            workspace_id=1, business=self.business, customer=self.customer,
+            invoice_number=number, invoice_date="2026-05-01",
+            type_of_invoice=INVOICE_TYPE_OUTWARD, total_amount=0,
+        )
+        for qty, rate, gst in lines:
+            taxable = D(str(qty)) * D(str(rate)); tax = taxable * D(str(gst))
+            LineItem.objects.create(
+                workspace_id=1, customer=self.customer, invoice=inv,
+                product_name="Item", hsn_code="711319", gst_tax_rate=D(str(gst)),
+                quantity=D(str(qty)), rate=D(str(rate)),
+                cgst=tax / 2, sgst=tax / 2, igst=D("0"),
+                amount=taxable + tax, unit="gms",
+            )
+        return inv
+
+    def test_monthly_outward_tax_is_join_safe_and_month_scoped(self):
+        self._mk("MAY-1", [(10, 100, "0.03"), (5, 200, "0.03")])
+        resp = self.client.get(reverse("invoice-stats"))
+        months = {(m["year"], m["month"]): m for m in resp.data["monthly"]}
+        may = months[(2026, 5)]
+        # taxable 1000+1000=2000 → tax 60 across both lines, exactly once
+        self.assertAlmostEqual(may["outward_tax"], 60.0, places=2)
+        self.assertEqual(may["outward_count"], 1)
+        # Global invariant: the monthly tax figures partition the outward
+        # total exactly — every line counted once, none double-joined.
+        # (The base fixture's invoice contributes to its own month, so
+        # asserting "other months are zero" would be wrong.)
+        db_total = sum(
+            float(li.cgst + li.sgst + li.igst)
+            for li in LineItem.objects.filter(invoice__type_of_invoice=INVOICE_TYPE_OUTWARD)
+        )
+        self.assertAlmostEqual(sum(m["outward_tax"] for m in months.values()), db_total, places=2)

--- a/sweet-rebuild-suite-main/src/components/CommandPalette.tsx
+++ b/sweet-rebuild-suite-main/src/components/CommandPalette.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { Search, FileText, Users, Package, Building2, BarChart3, Calculator, Settings, HardDrive, History, LayoutDashboard } from "lucide-react";
+import { Search, FileText, Users, Package, Building2, BarChart3, Calculator, Settings, HardDrive, History, LayoutDashboard, ReceiptText } from "lucide-react";
 import { CommandDialog, CommandInput, CommandList, CommandEmpty, CommandGroup, CommandItem } from "@/components/ui/command";
 import { formatCurrency } from "@/utils/mockData";
 import { cn } from "@/utils/utils";
@@ -12,6 +12,7 @@ const pages = [
   { label: "Businesses", href: "/billing/business/list", icon: Building2, shortcut: "B" },
   { label: "Products", href: "/billing/product/list", icon: Package, shortcut: "P" },
   { label: "Invoices", href: "/billing/invoice/list", icon: FileText, shortcut: "I" },
+  { label: "Inward Bills", href: "/billing/inward-bills", icon: ReceiptText, shortcut: "W" },
   { label: "Reports", href: "/billing/reports", icon: BarChart3, shortcut: "R" },
   { label: "GST", href: "/billing/gst-summary", icon: Calculator, shortcut: "G" },
   { label: "GSTR-1 Filing", href: "/billing/gst-summary?tab=gstr1", icon: FileText, shortcut: "" },

--- a/sweet-rebuild-suite-main/src/components/mobile/easy/EasyDashboard.tsx
+++ b/sweet-rebuild-suite-main/src/components/mobile/easy/EasyDashboard.tsx
@@ -13,12 +13,23 @@ interface Props {
 export default function EasyDashboard({ selectedFY }: Props) {
   const { data: statsData, isLoading } = useDashboardStats({ fyFilter: selectedFY });
   const totals = statsData?.totals || { outward: 0, inward: 0, count: 0, tax: 0 };
-  // The tile badge must name the period the numbers actually cover. It used to
-  // show the current month next to full-financial-year totals, so August read
-  // as "Tax ₹29,249 · 12 invoices" when August itself was ₹13,853 across 7 —
-  // over double, on the screen aimed at the least technical user. Showing a
-  // real month here means fetching month-scoped stats; until then, label the FY.
-  const periodLabel = `FY ${selectedFY}`;
+  // The tile badge must name the period the numbers actually cover. The
+  // monthly rollup now carries outward_tax (summed on line items, join-safe),
+  // so the tile can finally show the current filing month — which is what the
+  // 20th-of-the-month question actually is. Falls back to FY totals early in
+  // a month with no activity yet.
+  const now = new Date();
+  const thisMonth = (statsData?.monthly || []).find(
+    (m: any) => m.month === now.getMonth() + 1 && m.year === now.getFullYear()
+  );
+  const monthHasActivity = !!thisMonth && (thisMonth.outward_count + thisMonth.inward_count) > 0;
+  const periodLabel = monthHasActivity
+    ? now.toLocaleString("en-IN", { month: "long" })
+    : `FY ${selectedFY}`;
+  const tileTax = monthHasActivity ? Number(thisMonth.outward_tax) || 0 : Number(totals.tax) || 0;
+  const tileCount = monthHasActivity
+    ? thisMonth.outward_count + thisMonth.inward_count
+    : totals.count;
 
   const recentInvoices = useMemo(
     () => (statsData?.recent_invoices || []).map(mapDjangoInvoice),
@@ -69,7 +80,7 @@ export default function EasyDashboard({ selectedFY }: Props) {
                 <span className="premium-badge text-[9px] bg-primary/12 text-primary">{periodLabel}</span>
               </div>
               <p className="text-[11px] text-muted-foreground mt-0.5 tabular-nums">
-                Tax {formatCurrency(Number(totals.tax) || 0)} · {totals.count} invoice{totals.count === 1 ? "" : "s"}
+                Tax {formatCurrency(tileTax)} · {tileCount} invoice{tileCount === 1 ? "" : "s"}
               </p>
             </div>
             <ArrowRight className="w-4 h-4 text-muted-foreground" />

--- a/sweet-rebuild-suite-main/src/pages/GSTSummary.tsx
+++ b/sweet-rebuild-suite-main/src/pages/GSTSummary.tsx
@@ -450,11 +450,17 @@ export default function GSTSummary() {
         {useCustomRange ? (
           <DateRangePicker startDate={customStart} endDate={customEnd} onStartChange={setCustomStart} onEndChange={setCustomEnd} fyStart={fyStart} />
         ) : (
-          <div className={cn("flex rounded-xl overflow-hidden border border-border", isMobile ? "overflow-x-auto max-w-full -mx-1 px-1" : "flex-shrink-0")}>
-            <button onClick={() => setSelectedMonth("All")} className={cn("px-3 py-2 text-[11px] font-medium transition-all whitespace-nowrap", selectedMonth === "All" ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-secondary/40")}>All</button>
-            {MONTHS.map((m) => (
-              <button key={m} onClick={() => setSelectedMonth(m)} className={cn("px-2 py-2 text-[11px] font-medium transition-all whitespace-nowrap", selectedMonth === m ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-secondary/40")}>{m.slice(0, 3)}</button>
-            ))}
+          /* relative wrapper + right-edge fade: at 375px most month pills sit
+             off-screen in this scroll strip with nothing signalling "more
+             this way". Fade only on mobile, where the strip actually scrolls. */
+          <div className="relative">
+            <div className={cn("flex rounded-xl overflow-hidden border border-border", isMobile ? "overflow-x-auto max-w-full -mx-1 px-1" : "flex-shrink-0")}>
+              <button onClick={() => setSelectedMonth("All")} className={cn("px-3 py-2 text-[11px] font-medium transition-all whitespace-nowrap", selectedMonth === "All" ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-secondary/40")}>All</button>
+              {MONTHS.map((m) => (
+                <button key={m} onClick={() => setSelectedMonth(m)} className={cn("px-2 py-2 text-[11px] font-medium transition-all whitespace-nowrap", selectedMonth === m ? "bg-primary text-primary-foreground" : "text-muted-foreground hover:bg-secondary/40")}>{m.slice(0, 3)}</button>
+              ))}
+            </div>
+            {isMobile && <div aria-hidden className="pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-background to-transparent" />}
           </div>
         )}
       </motion.div>
@@ -653,12 +659,17 @@ export default function GSTSummary() {
       {/* Tabs */}
       <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.35, duration: 0.5 }}
         className="elevated-card rounded-2xl overflow-hidden">
-        <div className="flex border-b border-border/50 overflow-x-auto">
-          {TABS.map((t) => (
-            <button key={t.key} onClick={() => setTab(t.key)} className={cn("px-5 py-3 text-[12px] font-semibold border-b-2 -mb-px transition-all whitespace-nowrap", activeTab === t.key ? "border-primary text-primary" : "border-transparent text-muted-foreground")}>
-              {t.label}
-            </button>
-          ))}
+        {/* 4 of the 5 GSTR tabs sit off-screen at 375px — fade signals the
+            scroll. from-card because this strip lives inside the elevated card. */}
+        <div className="relative">
+          <div className="flex border-b border-border/50 overflow-x-auto">
+            {TABS.map((t) => (
+              <button key={t.key} onClick={() => setTab(t.key)} className={cn("px-5 py-3 text-[12px] font-semibold border-b-2 -mb-px transition-all whitespace-nowrap", activeTab === t.key ? "border-primary text-primary" : "border-transparent text-muted-foreground")}>
+                {t.label}
+              </button>
+            ))}
+          </div>
+          <div aria-hidden className="pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-card to-transparent md:hidden" />
         </div>
 
         {/* Summary tab — rate slab + GSTR-3B + HSN */}

--- a/sweet-rebuild-suite-main/src/pages/InvoiceForm.tsx
+++ b/sweet-rebuild-suite-main/src/pages/InvoiceForm.tsx
@@ -1,5 +1,5 @@
 import { logger } from "@/utils/logger";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useParams, useNavigate, Link, useLocation } from "react-router-dom";
 import { formatCurrency, itemUnits, itemUnitLabels, currentFY } from "@/utils/mockData";
 import DraftRestoreBanner from "@/components/DraftRestoreBanner";
@@ -12,6 +12,7 @@ import {
   FileText, Package, Calculator, CheckCircle2, IndianRupee, UserPlus,
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
+import { isIntraState } from "@/utils/taxRules";
 import { cn } from "@/utils/utils";
 import { motion, AnimatePresence } from "framer-motion";
 import QuickCustomerModal from "@/components/QuickCustomerModal";
@@ -201,6 +202,7 @@ export default function InvoiceForm({ mode }: InvoiceFormProps) {
 
   const [dirty, setDirty] = useState(false);
   const [showUnsavedModal, setShowUnsavedModal] = useState(false);
+  const [showTaxAdjust, setShowTaxAdjust] = useState(false);
   const [pendingNav, setPendingNav] = useState<string | null>(null);
   const [showQuickCustomer, setShowQuickCustomer] = useState(false);
   const [showDraftBanner, setShowDraftBanner] = useState(false);
@@ -319,14 +321,25 @@ export default function InvoiceForm({ mode }: InvoiceFormProps) {
   // wrong tax heads.
   const selectedCustomer = localCustomers.find((c) => String(c.id) === String(form.customerId));
   const selectedBusiness = effectiveBusinesses.find((b) => String(b.id) === String(form.businessId));
-  const isInterstate = selectedBusiness && selectedCustomer && selectedBusiness.state_name !== selectedCustomer.state_name;
+  // Same rule as billing/tax_rules.py (GSTIN state codes first, state_name
+  // fallback) so the chip below, the client math, and the server's re-derived
+  // heads can never disagree.
+  const isInterstate = !!(selectedBusiness && selectedCustomer) && !isIntraState(
+    selectedCustomer.gst_number, selectedBusiness.gst_number,
+    selectedCustomer.state_name, selectedBusiness.state_name,
+  );
 
+  // Keep isIGST synced to the detected direction BOTH ways (the old effect
+  // only ever switched it on, never back). Manual override via "Adjust" wins,
+  // and edit mode never auto-rewrites what a stored invoice already says —
+  // InvoiceDetail's mismatch banner owns that conversation.
+  const igstManual = useRef(false);
   useEffect(() => {
-    if (isInterstate && !form.isIGST) {
-      set("isIGST", true);
-      toast({ title: "Auto-detected IGST", description: `${selectedBusiness?.state_name} → ${selectedCustomer?.state_name}` });
-    }
-  }, [form.businessId, form.customerId]);
+    if (mode === "edit" || igstManual.current) return;
+    if (!selectedBusiness || !selectedCustomer) return;
+    if (form.isIGST !== isInterstate) set("isIGST", isInterstate);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [form.businessId, form.customerId, isInterstate]);
 
   useEffect(() => {
     const handler = (e: BeforeUnloadEvent) => { if (dirty) { e.preventDefault(); e.returnValue = ""; } };
@@ -558,12 +571,25 @@ export default function InvoiceForm({ mode }: InvoiceFormProps) {
                 </div>
                 <div className="space-y-1.5">
                   <label className="text-[11px] font-semibold text-foreground uppercase tracking-wider">GST Type</label>
-                  <div className="flex items-center gap-3 h-10">
-                    <label className="flex items-center gap-2 cursor-pointer">
-                      <input type="checkbox" checked={form.isIGST} onChange={(e) => set("isIGST", e.target.checked)} className="accent-primary w-4 h-4" />
-                      <span className="text-[13px] text-foreground">IGST</span>
-                    </label>
-                    {isInterstate && <span className="premium-badge bg-warning/12 text-warning text-[10px]">Interstate</span>}
+                  {/* Read-out, not a decision: direction is auto-detected and
+                      the server re-derives the heads anyway. The raw checkbox
+                      (which silently rewired tax columns, on the screen Easy
+                      mode users see) now lives behind "Adjust" for the rare
+                      genuine override. */}
+                  <div className="flex items-center gap-2.5 h-10 flex-wrap">
+                    <span className={cn("premium-badge text-[10px]", form.isIGST ? "bg-warning/12 text-warning" : "bg-success/12 text-success")}>
+                      {form.isIGST ? "Inter-state · IGST" : "Local · CGST + SGST"}
+                    </span>
+                    {showTaxAdjust ? (
+                      <label className="flex items-center gap-2 cursor-pointer">
+                        <input type="checkbox" checked={form.isIGST} onChange={(e) => { igstManual.current = true; set("isIGST", e.target.checked); }} className="accent-primary w-4 h-4" />
+                        <span className="text-[13px] text-foreground">IGST</span>
+                      </label>
+                    ) : (
+                      <button type="button" onClick={() => setShowTaxAdjust(true)} className="text-[11px] text-muted-foreground hover:text-foreground underline underline-offset-2">
+                        Adjust
+                      </button>
+                    )}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Four verified quick wins from the registry audit backlog:

1. **IGST checkbox → direction chip.** Auto-detected via the shared GSTIN-first rule, synced both ways as parties change (the old effect could turn IGST on but never back off), raw checkbox behind "Adjust" for real overrides. Edit mode never rewrites stored heads.
2. **Easy-mode GST tile is finally month-true.** `/api/invoices/stats/` monthly rollup now carries `outward_tax` (LineItem-aggregated — join-safe, with a partition-invariant test), so the tile shows the current filing month instead of FY totals wearing a month label. Falls back to FY when the month is empty.
3. **Inward Bills in the ⌘K palette.**
4. **Scroll fades on GST Summary's tab/month strips** — 4 of 5 GSTR tabs were invisible off-edge at 375px with no hint.

Verified live in the running app (chip 08↔27 both directions, tile August ₹3,165/2 vs FY ₹7,305/3, fades at 375px). 139 backend tests, 46 vitest, 0 type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)