### PR TITLE
chore: enable Dependabot (weekly, grouped)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+# Dependency updates. This exists because the app sat on Django 4.2.2 — a
+# June-2023 patch of a line that later went EOL — on the public internet for
+# three years. Weekly, grouped, so it's one digestible PR per ecosystem
+# instead of a flood.
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      python-minor-and-patch:
+        update-types: ["minor", "patch"]
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/sweet-rebuild-suite-main"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      frontend-minor-and-patch:
+        update-types: ["minor", "patch"]
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/e2e-tests"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      e2e-minor-and-patch:
+        update-types: ["minor", "patch"]
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 2


### PR DESCRIPTION
Weekly grouped dependency PRs for the four ecosystems (uv/pyproject, the two npm trees, GitHub Actions). Minor+patch bumps arrive as one grouped PR per ecosystem; majors come individually.

Context: the app sat on Django 4.2.2 — a June-2023 patch — until this week, on the public internet, with nothing watching. This closes that gap going forward.

One admin follow-up (can't be done from a PR): **Settings → Advanced Security → enable Dependabot alerts** so known-CVE bumps arrive immediately rather than on the weekly schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)