### PR TITLE
perf: stop re-summing invoices once per line item (5 paths, query-budget tested)

### DIFF
--- a/billing/api/inward_bills.py
+++ b/billing/api/inward_bills.py
@@ -176,20 +176,31 @@ class InwardBillListCreateView(APIView):
             })
         bill_total = request.data.get("bill_total")
         bill_total = Decimal(str(bill_total)) if bill_total not in (None, "") else None
-        computed, _total = compute_lines(service_lines, intra=intra, bill_total=bill_total)
+        computed, total = compute_lines(service_lines, intra=intra, bill_total=bill_total)
 
         invoice = Invoice.objects.create(
             workspace_id=WORKSPACE_ID, business=business, customer=supplier,
             invoice_number=invoice_number, invoice_date=invoice_date,
             type_of_invoice=INVOICE_TYPE_INWARD, total_amount=Decimal("0"),
         )
-        for c in computed:
-            LineItem.objects.create(
-                workspace_id=WORKSPACE_ID, customer=supplier, invoice=invoice,
-                product_name=c["product_name"], hsn_code=c["hsn_code"],
-                gst_tax_rate=c["gst_tax_rate"], quantity=c["quantity"], rate=c["price_rate"],
-                cgst=c["cgst"], sgst=c["sgst"], igst=c["igst"], amount=c["amount"], unit=c["unit"],
-            )
+        # bulk_create skips the per-line signal; compute_lines already returned
+        # the round-off-adjusted total, so store that instead of re-summing.
+        LineItem.objects.bulk_create(
+            [
+                LineItem(
+                    workspace_id=WORKSPACE_ID, customer=supplier, invoice=invoice,
+                    product_name=c["product_name"], hsn_code=c["hsn_code"],
+                    gst_tax_rate=c["gst_tax_rate"], quantity=c["quantity"], rate=c["price_rate"],
+                    cgst=c["cgst"], sgst=c["sgst"], igst=c["igst"], amount=c["amount"], unit=c["unit"],
+                )
+                for c in computed
+            ],
+            batch_size=100,
+        )
+        # In-memory too: _store_file_and_preview saves the instance (file
+        # field), and a stale 0 here would clobber the total just written.
+        invoice.total_amount = total
+        Invoice.objects.filter(pk=invoice.pk).update(total_amount=total)
         _store_file_and_preview(invoice, request.FILES.get("file"))
         invoice.refresh_from_db()
         return Response(

--- a/billing/api/views.py
+++ b/billing/api/views.py
@@ -3600,20 +3600,27 @@ class AIInvoiceCreateView(APIView):
                     type_of_invoice=INVOICE_TYPE_INWARD,
                     total_amount=primary_invoice.total_amount,
                 )
-                for li in LineItem.objects.filter(invoice=primary_invoice):
-                    LineItem.objects.create(
-                        customer=supplier_cust,
-                        invoice=mirror,
-                        product_name=li.product_name,
-                        hsn_code=li.hsn_code,
-                        gst_tax_rate=li.gst_tax_rate,
-                        quantity=li.quantity,
-                        rate=li.rate,
-                        amount=li.amount,
-                        cgst=li.cgst,
-                        sgst=li.sgst,
-                        igst=li.igst,
-                    )
+                # bulk_create: the per-line signal would re-sum the mirror
+                # once per copied line; the total is set explicitly below.
+                LineItem.objects.bulk_create(
+                    [
+                        LineItem(
+                            customer=supplier_cust,
+                            invoice=mirror,
+                            product_name=li.product_name,
+                            hsn_code=li.hsn_code,
+                            gst_tax_rate=li.gst_tax_rate,
+                            quantity=li.quantity,
+                            rate=li.rate,
+                            amount=li.amount,
+                            cgst=li.cgst,
+                            sgst=li.sgst,
+                            igst=li.igst,
+                        )
+                        for li in LineItem.objects.filter(invoice=primary_invoice)
+                    ],
+                    batch_size=100,
+                )
                 mirror.total_amount = primary_invoice.total_amount
                 mirror.save()
                 # Audit image on the mirror too — same physical document.
@@ -3723,7 +3730,8 @@ class AIInvoiceCreateView(APIView):
             # actual tax-inclusive total, internally consistent.
             from decimal import Decimal as _D
             is_igst = invoice.is_igst_applicable
-            line_items_created = 0
+            new_lis = []
+            running_total = _D("0")
             for item_data in invoice_data.get("line_items", []) or []:
                 qty = _D(str(item_data.get("quantity", 0) or 0))
                 rate = _D(str(item_data.get("rate", 0) or 0))
@@ -3736,7 +3744,8 @@ class AIInvoiceCreateView(APIView):
                 else:
                     cgst = sgst = tax / _D("2")
                     igst = _D("0")
-                LineItem.objects.create(
+                running_total += amount
+                new_lis.append(LineItem(
                     customer=customer,
                     invoice=invoice,
                     product_name=item_data.get("product_name", "") or "",
@@ -3748,18 +3757,17 @@ class AIInvoiceCreateView(APIView):
                     cgst=cgst,
                     sgst=sgst,
                     igst=igst,
-                )
-                line_items_created += 1
+                ))
+            # bulk_create skips the per-line resync signal (which would re-sum
+            # the invoice once per line); the total is the running sum of the
+            # recomputed amounts, so no post-hoc SELECT is needed either.
+            LineItem.objects.bulk_create(new_lis, batch_size=100)
+            line_items_created = len(new_lis)
 
-            # Recompute invoice total from line items — `amount` is the
-            # tax-inclusive line subtotal (matches InvoiceForm's contract),
-            # so summing gives the true total even if the AI's
-            # `total_amount` was off.
-            invoice.total_amount = sum(
-                LineItem.objects.filter(invoice=invoice).values_list(
-                    "amount", flat=True
-                )
-            )
+            # `amount` is the tax-inclusive line subtotal (matches
+            # InvoiceForm's contract), so its sum is the true total even if
+            # the AI's `total_amount` was off.
+            invoice.total_amount = running_total
             invoice.save()
 
             # Inter-firm: also write the INWARD mirror for the buyer firm

--- a/billing/services/gstr2a_import.py
+++ b/billing/services/gstr2a_import.py
@@ -561,12 +561,11 @@ def import_file(
                 invoice_number=row.invoice_number,
                 invoice_date=row.invoice_date,
                 type_of_invoice=INVOICE_TYPE_INWARD,
-                # total_amount is recomputed via LineItem signal on save,
-                # but set initial value so it's right even if signals are
-                # disabled in a future refactor.
+                # bulk_create below skips the resync signal, so this stored
+                # total IS the final value (and equals the line amount).
                 total_amount=row.invoice_value,
             )
-            LineItem.objects.create(
+            LineItem.objects.bulk_create([LineItem(
                 invoice=invoice,
                 customer=cust,
                 product_name=f"GSTR-2A import · {row.supplier_name[:80]}",
@@ -579,7 +578,7 @@ def import_file(
                 igst=row.igst,
                 amount=row.invoice_value,  # tax-inclusive (matches app contract)
                 unit="lot",
-            )
+            )])
             result.created_invoices += 1
             result.created_line_items += 1
             result.created_detail.append(

--- a/billing/signals.py
+++ b/billing/signals.py
@@ -1,30 +1,36 @@
+from django.db.models import Sum
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
 from billing.models import Invoice, LineItem
 
+# Safety net for one-off saves (admin edits, shell fixes). Every bulk path —
+# invoice create/update_line_items, inward capture, CSV/AI/GSTR-2A imports —
+# uses bulk_create/_raw_delete precisely so these never fire per line; they
+# set total_amount themselves from totals they already hold.
+
+
+def _resync_invoice_total(invoice):
+    """Sum in SQL, write with .update() (no Invoice.save() side effects), and
+    keep the in-memory instance in step — callers hold references to it and a
+    later instance.save() must not write a stale total back."""
+    total = (
+        LineItem.objects.filter(invoice_id=invoice.id).aggregate(t=Sum("amount"))["t"]
+        or 0
+    )
+    Invoice.objects.filter(id=invoice.id).update(total_amount=total)
+    invoice.total_amount = total
+
 
 @receiver(post_save, sender=LineItem)
 def update_invoice_total_on_line_item_save(sender, instance, **kwargs):
-    """Update the invoice total amount when a line item is saved."""
-    invoice = instance.invoice
-    invoice.total_amount = sum(
-        LineItem.objects.filter(invoice=invoice).values_list("amount", flat=True)
-    )
-    # Use update to avoid triggering the save method again
-    Invoice.objects.filter(id=invoice.id).update(total_amount=invoice.total_amount)
+    _resync_invoice_total(instance.invoice)
 
 
 @receiver(post_delete, sender=LineItem)
 def update_invoice_total_on_line_item_delete(sender, instance, **kwargs):
-    """Update the invoice total amount when a line item is deleted."""
     try:
-        invoice = instance.invoice
-        invoice.total_amount = sum(
-            LineItem.objects.filter(invoice=invoice).values_list("amount", flat=True)
-        )
-        # Use update to avoid triggering the save method again
-        Invoice.objects.filter(id=invoice.id).update(total_amount=invoice.total_amount)
+        _resync_invoice_total(instance.invoice)
     except Invoice.DoesNotExist:
-        # Invoice might have been deleted already
+        # Cascade delete — the invoice went first.
         pass

--- a/billing/tests/test_line_item_write_paths.py
+++ b/billing/tests/test_line_item_write_paths.py
@@ -1,0 +1,100 @@
+"""Line-item write paths must not scale queries with line count.
+
+The resync signal (billing/signals.py) re-sums an invoice on every LineItem
+save — the right behavior for one-off admin edits, and an O(n²)-reads storm
+if a bulk path loops .create(). Every bulk path therefore uses bulk_create
+and sets total_amount from a total it already holds. These tests pin both
+halves: bulk paths stay O(1) in queries, and the signal safety net still
+works for genuine single saves.
+"""
+
+import json
+from decimal import Decimal as D
+
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+
+from billing.constants import INVOICE_TYPE_OUTWARD
+from billing.models import Invoice, LineItem
+from billing.tests.test_base import BaseAPITestCase
+
+
+class InwardCaptureQueryBudgetTest(BaseAPITestCase):
+    def _capture(self, n_lines, number):
+        payload = {
+            "business_id": self.business.id,
+            "supplier_name": "QUERY BUDGET SUPPLIER",
+            "invoice_number": number,
+            "invoice_date": "2026-08-10",
+            "lines": json.dumps([
+                {"product_name": f"Item {i}", "hsn_code": "711311",
+                 "quantity": "1", "rate": "100", "taxable": "100",
+                 "gst_tax_rate": "0.03"}
+                for i in range(n_lines)
+            ]),
+        }
+        with CaptureQueriesContext(connection) as ctx:
+            resp = self.client.post(reverse("inward-bill-list"), payload)
+        self.assertEqual(resp.status_code, 201, resp.data)
+        return resp.data, len(ctx.captured_queries)
+
+    def test_query_count_does_not_grow_with_line_count(self):
+        # Warm-up so the supplier get_or_create resolves to a plain get in
+        # both measured runs (its INSERT + M2M add would skew the first).
+        self._capture(1, "QB-WARMUP")
+        # Two lines vs eight: with the old per-line .create() loop the
+        # difference was 3 queries per extra line (insert + signal's
+        # SELECT + UPDATE). With bulk_create it must be exactly zero.
+        _, q_small = self._capture(2, "QB-SMALL")
+        _, q_large = self._capture(8, "QB-LARGE")
+        self.assertEqual(
+            q_large, q_small,
+            f"query count grew with line count ({q_small} -> {q_large}); "
+            "a per-line save crept back into the inward capture path",
+        )
+
+    def test_capture_total_still_matches_the_lines(self):
+        bill, _ = self._capture(3, "QB-TOTAL")
+        inv = Invoice.objects.get(id=bill["id"])
+        db_sum = sum(
+            (li.amount for li in LineItem.objects.filter(invoice=inv)), D("0")
+        )
+        self.assertEqual(inv.total_amount, db_sum)
+        self.assertEqual(db_sum, D("309"))  # 3 × (100 + 3% tax)
+
+
+class SignalSafetyNetTest(BaseAPITestCase):
+    """One-off saves (admin edits, shell fixes) still resync the total."""
+
+    def _bare_invoice(self, number):
+        return Invoice.objects.create(
+            workspace_id=1, business=self.business, customer=self.customer,
+            invoice_number=number, invoice_date="2026-08-01",
+            type_of_invoice=INVOICE_TYPE_OUTWARD, total_amount=0,
+        )
+
+    def _line(self, invoice, amount):
+        return LineItem.objects.create(
+            workspace_id=1, customer=self.customer, invoice=invoice,
+            product_name="Loose Item", hsn_code="711319",
+            gst_tax_rate=D("0.03"), quantity=D("1"), rate=D(str(amount)),
+            cgst=D("0"), sgst=D("0"), igst=D("0"), amount=D(str(amount)),
+            unit="gms",
+        )
+
+    def test_single_create_resyncs_total(self):
+        inv = self._bare_invoice("NET-1")
+        self._line(inv, 500)
+        self._line(inv, 250)
+        inv.refresh_from_db()
+        self.assertEqual(inv.total_amount, D("750"))
+
+    def test_single_delete_resyncs_total(self):
+        inv = self._bare_invoice("NET-2")
+        keep = self._line(inv, 500)
+        drop = self._line(inv, 250)
+        drop.delete()
+        inv.refresh_from_db()
+        self.assertEqual(inv.total_amount, D("500"))
+        self.assertEqual(LineItem.objects.filter(invoice=inv).get().id, keep.id)

--- a/billing/utils.py
+++ b/billing/utils.py
@@ -364,7 +364,8 @@ def process_invoice_csv(
     2. Validates that customers exist in the database (doesn't create new ones)
     3. Filters customers by business association to ensure data integrity
     """
-    from billing.models import Business, Customer, Invoice, LineItem
+    from billing.constants import GST_TAX_RATE, HSN_CODE
+    from billing.models import Business, Customer, Invoice, LineItem, Product
 
     # Initialize result counters
     logger.info(f"Processing invoices from CSV file: {file_content}")
@@ -539,6 +540,10 @@ def process_invoice_csv(
 
         # Process each invoice with its line items in a transaction
         with transaction.atomic():
+            # One catalog read for the whole file (Product.name is unique) —
+            # the old per-line helper SELECTed the product and the invoice
+            # again for every row.
+            products_by_name = {p.name: p for p in Product.objects.all()}
             for invoice_number, data in invoice_data.items():
                 invoice_info = data["invoice_info"]
                 line_items_data = data["line_items"]
@@ -571,21 +576,44 @@ def process_invoice_csv(
 
                 result["invoices_created"] += 1
 
-                # Create line items for the invoice
+                # Line items are built in memory and bulk_created so the
+                # per-line resync signal doesn't re-sum the invoice once per
+                # row — imports are the largest n this code ever sees. Same
+                # math as LineItem.create_line_item_for_invoice, minus its
+                # two per-row SELECTs (product, invoice).
+                is_igst = invoice.is_igst_applicable
+                new_lis = []
+                new_total = Decimal("0")
                 for item_data in line_items_data:
                     try:
-                        # Convert quantity and rate to Decimal
                         quantity = Decimal(str(item_data["quantity"]))
                         rate = Decimal(str(item_data["rate"]))
-
-                        # Create line item
-                        LineItem.create_line_item_for_invoice(
-                            invoice_id=invoice.id,
-                            product_name=item_data["product_name"],
-                            quantity=quantity,
-                            rate=rate,
+                        product = products_by_name.get(item_data["product_name"])
+                        hsn_code = product.hsn_code if product else HSN_CODE
+                        gst_rate = product.gst_tax_rate if product else GST_TAX_RATE
+                        net_amount = quantity * rate
+                        tax_amount = net_amount * gst_rate
+                        if is_igst:
+                            cgst, sgst, igst = Decimal("0"), Decimal("0"), tax_amount
+                        else:
+                            cgst = sgst = tax_amount / 2
+                            igst = Decimal("0")
+                        new_lis.append(
+                            LineItem(
+                                product_name=item_data["product_name"],
+                                quantity=quantity,
+                                rate=rate,
+                                invoice_id=invoice.id,
+                                hsn_code=hsn_code,
+                                customer_id=invoice.customer_id,
+                                gst_tax_rate=gst_rate,
+                                cgst=cgst,
+                                sgst=sgst,
+                                igst=igst,
+                                amount=net_amount + tax_amount,
+                            )
                         )
-
+                        new_total += net_amount + tax_amount
                         result["line_items_created"] += 1
                     except Exception as e:
                         logger.warning(
@@ -595,8 +623,9 @@ def process_invoice_csv(
                             f"Error creating line item for invoice {invoice_number}: {e!s}"
                         )
 
-                # Update invoice total amount
-                invoice.save()  # This will recalculate the total_amount
+                LineItem.objects.bulk_create(new_lis, batch_size=100)
+                invoice.total_amount = new_total
+                Invoice.objects.filter(pk=invoice.pk).update(total_amount=new_total)
 
     except Exception as e:
         if isinstance(e, CSVImportError):


### PR DESCRIPTION
## What

Closes the last of the audit's "signals still re-sum per line" finding. The `LineItem` post-save/post-delete signal re-sums the whole invoice on every line save — correct as a safety net for one-off admin edits, an **O(n²)-reads storm** when a bulk path loops `.create()`. Invoice create/`update_line_items` already bypassed it; five paths still fired it per line:

| Path | Before | After |
|---|---|---|
| Inward capture | 3 queries/line; `compute_lines`' round-off-adjusted total **computed then discarded**, total rebuilt by the signal | `bulk_create` + that total stored directly |
| CSV import | ~5 queries/line (`create_line_item_for_invoice` re-SELECTed the product **and** the invoice per row, then the signal re-summed) | one catalog read per file, `bulk_create` per invoice, explicit total |
| AI invoice create | per-line create + a post-hoc SELECT of every amount | `bulk_create` + running total |
| Inter-firm mirror | per-line copy loop | `bulk_create` |
| GSTR-2A import | 2 extra queries per imported row (a 500-row file paid ~1,000) | `bulk_create` the synthetic line |

The signal itself now **sums in SQL** (`aggregate(Sum)`) instead of fetching every amount into Python — and deliberately keeps updating the caller's in-memory instance.

## The subtle bit

The old signal mutated `instance.invoice.total_amount` in memory as a side effect (via the FK cache). Two places quietly depended on that: `test_base`'s fixture flow, and inward capture, where `_store_file_and_preview` saves the instance again — with a stale in-memory `0`, that save **clobbers the total just written**. The first draft of this change dropped the side effect and the new query-budget test caught the clobber immediately. The rewrite keeps the in-memory sync on the signal path and sets totals in-memory explicitly on the bulk paths before any later `save()`.

## Tests (4 new, `test_line_item_write_paths.py`)

- **Query budget:** an 8-line inward capture must issue *exactly* the same number of queries as a 2-line one (after a warm-up so supplier `get_or_create` noise doesn't skew it). Was +3/line.
- Capture totals still reconcile to the paisa (₹309 for 3 × ₹100 @ 3%).
- The signal safety net still resyncs on genuine single-line create and delete.

**169 backend tests pass** (165 + 4 new) — the existing inward/CSV/AI/2A totals tests all validate the refactor's money math unchanged.

## Overlap

Base `main`. Touches `billing/api/views.py` in two regions (~L3600 mirror, ~L3755 AI create) — #80's hunks are at ~L1300; no other open PR touches these five files. Merges cleanly in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
