### PR TITLE
feat: HSN drift drill-down on ProductDetail (the story behind "+N more")

### DIFF
--- a/billing/api/views.py
+++ b/billing/api/views.py
@@ -673,6 +673,46 @@ class ProductViewSet(AuditLogMixin, viewsets.ModelViewSet):
 
         return Response(defaults)
 
+    @action(detail=True, methods=["get"])
+    def hsn_usage(self, request, pk=None):
+        """How this product's name actually appears on invoice lines, grouped
+        by HSN code — the drill-down behind Top Products' "+N more" flag.
+
+        Line items store product_name as text, so when the catalog HSN
+        changes (or an import carried its own code) the history drifts
+        silently. Each variant is named with its usage window so the drift
+        can be repaired: new lines follow the catalog automatically, old
+        lines are fixed by editing their invoices.
+        """
+        from django.db.models import Max, Min
+
+        product = self.get_object()
+        rows = (
+            LineItem.objects.filter(product_name=product.name)
+            .values("hsn_code")
+            .annotate(
+                lines=Count("id"),
+                quantity=Sum("quantity"),
+                amount=Sum("amount"),
+                first_used=Min("invoice__invoice_date"),
+                last_used=Max("invoice__invoice_date"),
+            )
+            .order_by("-lines")
+        )
+        catalog = (product.hsn_code or "").strip()
+        return Response(
+            {
+                "catalog_hsn": catalog,
+                "variants": [
+                    {
+                        **r,
+                        "matches_catalog": (r["hsn_code"] or "").strip() == catalog,
+                    }
+                    for r in rows
+                ],
+            }
+        )
+
 
 @method_decorator(csrf_exempt, name="dispatch")
 class InvoiceViewSet(AuditLogMixin, viewsets.ModelViewSet):

--- a/billing/tests/test_product_hsn_usage.py
+++ b/billing/tests/test_product_hsn_usage.py
@@ -1,0 +1,77 @@
+"""/api/products/:id/hsn_usage/ — the drill-down behind Top Products' "+N more".
+
+Line items store product_name as text, so HSN drift accumulates silently.
+The endpoint groups a product's line history by hsn_code and flags which
+rows match the catalog, so the drift can actually be repaired.
+"""
+
+from decimal import Decimal as D
+
+from django.urls import reverse
+
+from billing.constants import INVOICE_TYPE_OUTWARD
+from billing.models import Invoice, LineItem
+from billing.tests.test_base import BaseAPITestCase
+
+
+class ProductHsnUsageTest(BaseAPITestCase):
+    def _invoice(self, number, date):
+        return Invoice.objects.create(
+            workspace_id=1, business=self.business, customer=self.customer,
+            invoice_number=number, invoice_date=date,
+            type_of_invoice=INVOICE_TYPE_OUTWARD, total_amount=0,
+        )
+
+    def _line(self, invoice, name, hsn, qty=1):
+        return LineItem.objects.create(
+            workspace_id=1, customer=self.customer, invoice=invoice,
+            product_name=name, hsn_code=hsn, gst_tax_rate=D("0.03"),
+            quantity=D(str(qty)), rate=D("100"), cgst=D("1.5"), sgst=D("1.5"),
+            igst=D("0"), amount=D("103"), unit="gms",
+        )
+
+    def _usage(self):
+        resp = self.client.get(reverse("product-hsn-usage", args=[self.product.id]))
+        self.assertEqual(resp.status_code, 200, getattr(resp, "data", resp))
+        return resp.data
+
+    def test_groups_variants_and_flags_catalog_match(self):
+        # self.product: name "Test Product", catalog HSN 711319.
+        inv1 = self._invoice("HSN-U1", "2026-04-10")
+        inv2 = self._invoice("HSN-U2", "2026-05-10")
+        self._line(inv1, "Test Product", "711319")
+        self._line(inv1, "Test Product", "711319")
+        self._line(inv2, "Test Product", "711311")  # the drifted code
+
+        data = self._usage()
+        self.assertEqual(data["catalog_hsn"], "711319")
+        by_code = {v["hsn_code"]: v for v in data["variants"]}
+        self.assertTrue(by_code["711319"]["matches_catalog"])
+        self.assertFalse(by_code["711311"]["matches_catalog"])
+        # setUp's fixture line also carries 711319, so 2 + 1 = 3 there.
+        self.assertEqual(by_code["711319"]["lines"], 3)
+        self.assertEqual(by_code["711311"]["lines"], 1)
+        # Ordered by usage: the majority code comes first.
+        self.assertEqual(data["variants"][0]["hsn_code"], "711319")
+
+    def test_usage_window_dates(self):
+        self._line(self._invoice("HSN-U3", "2025-04-01"), "Test Product", "999999")
+        self._line(self._invoice("HSN-U4", "2026-01-15"), "Test Product", "999999")
+        data = self._usage()
+        drifted = next(v for v in data["variants"] if v["hsn_code"] == "999999")
+        self.assertEqual(str(drifted["first_used"]), "2025-04-01")
+        self.assertEqual(str(drifted["last_used"]), "2026-01-15")
+
+    def test_no_drift_is_a_single_matching_variant(self):
+        data = self._usage()  # only the fixture line exists
+        self.assertEqual(len(data["variants"]), 1)
+        self.assertTrue(data["variants"][0]["matches_catalog"])
+
+    def test_viewer_can_read(self):
+        from django.contrib.auth.models import Group, User
+
+        viewer = User.objects.create_user(username="ro", password="x")
+        viewer.groups.add(Group.objects.get_or_create(name="viewer")[0])
+        self.client.force_authenticate(user=viewer)
+        resp = self.client.get(reverse("product-hsn-usage", args=[self.product.id]))
+        self.assertEqual(resp.status_code, 200)

--- a/sweet-rebuild-suite-main/src/pages/ProductDetail.tsx
+++ b/sweet-rebuild-suite-main/src/pages/ProductDetail.tsx
@@ -10,7 +10,7 @@ import {
 import { motion } from "framer-motion";
 import { cn } from "@/utils/utils";
 import { useToast } from "@/hooks/use-toast";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
 import DeleteConfirmDialog from "@/components/DeleteConfirmDialog";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -31,6 +31,18 @@ export default function ProductDetail() {
   const { items: customers } = useCustomers();
   const [copiedField, setCopiedField] = useState<string | null>(null);
   const [deleteOpen, setDeleteOpen] = useState(false);
+  type HsnVariant = { hsn_code: string; lines: number; quantity: string; amount: string; first_used: string; last_used: string; matches_catalog: boolean };
+  const [hsnUsage, setHsnUsage] = useState<{ catalog_hsn: string; variants: HsnVariant[] } | null>(null);
+  useEffect(() => {
+    if (!id) return;
+    let alive = true;
+    api.get(`products/${id}/hsn_usage/`)
+      .then((res) => { if (alive) setHsnUsage(res.data); })
+      .catch(() => { /* the card simply doesn't render */ });
+    return () => { alive = false; };
+  }, [id]);
+  // Only worth a card when history disagrees with itself or the catalog.
+  const hsnDrift = hsnUsage && (hsnUsage.variants.length > 1 || hsnUsage.variants.some((v) => !v.matches_catalog));
 
   // Consistent loading + not-found treatment — mirrors InvoiceDetail.
   if (productLoading) return (
@@ -156,6 +168,34 @@ export default function ProductDetail() {
               </div>
             ))}
           </div>
+
+          {hsnDrift && hsnUsage && (
+            <div className="rounded-2xl p-5 space-y-3 bg-warning/5 border border-warning/20">
+              <div>
+                <h2 className="text-xs font-display font-semibold text-warning uppercase tracking-wider">HSN drift on invoice lines</h2>
+                <p className="text-[11px] text-muted-foreground mt-1">
+                  Lines keep the HSN they were saved with. New lines follow the catalog
+                  ({hsnUsage.catalog_hsn || "none"}); older ones are fixed by editing their invoices.
+                </p>
+              </div>
+              <div className="space-y-2">
+                {hsnUsage.variants.map((v) => (
+                  <div key={v.hsn_code || "(blank)"} className="flex items-center gap-3 p-2 rounded-xl bg-background/40">
+                    <span className="font-mono text-[12px] text-foreground shrink-0">{v.hsn_code || "(blank)"}</span>
+                    {v.matches_catalog ? (
+                      <span className="px-1.5 py-0.5 rounded text-[9px] font-bold uppercase bg-success/10 text-success shrink-0">catalog</span>
+                    ) : (
+                      <span className="px-1.5 py-0.5 rounded text-[9px] font-bold uppercase bg-warning/10 text-warning shrink-0">drift</span>
+                    )}
+                    <span className="text-[11px] text-muted-foreground ml-auto text-right">
+                      {v.lines} line{v.lines === 1 ? "" : "s"}
+                      <span className="block text-[10px]">{formatDate(v.first_used)} – {formatDate(v.last_used)}</span>
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
 
           {customerUsage.length > 0 && (
             <div className="elevated-card rounded-2xl p-5 space-y-3">


### PR DESCRIPTION
## What

The Top Products widget honestly flags HSN drift ("+1 more") since the stats regrouping fix — but it never showed **which** codes, **how many lines**, or **when**. This makes the drift repairable:

- **`GET /api/products/:id/hsn_usage/`** — groups the product's entire line history by `hsn_code`: line count, quantity, amount, first/last-used dates, and a `matches_catalog` flag per variant, majority code first. Server-side deliberately: line items store `product_name` as text and the client's invoice list is paginated, so any client-side rollup would undercount.
- **ProductDetail** — an "HSN drift on invoice lines" panel (warning wash, consistent with #87's callout idiom) that renders **only when history disagrees** with itself or the catalog. Each variant gets a `catalog`/`drift` badge and its usage window, with one line of repair guidance: *new lines follow the catalog automatically; older ones are fixed by editing their invoices.*

Dashboard's "+N more" already links to ProductDetail, so the drill-down needs no new navigation.

## Verified

- 4 new tests (`test_product_hsn_usage.py`): grouping + catalog flags + majority-first ordering, usage-window dates, single-variant baseline (no card), viewer-role read access — **173 backend tests pass**
- `tsc --noEmit` clean on the ship blobs; card verified live against seeded drift (2× `711319` catalog + 1× `711311` drift renders with correct badges, counts, and date ranges; clean products render no card)

## Overlap

Base `main`. `views.py` insert sits at the end of `ProductViewSet` (~L668) — disjoint from #80 (~L1300) and #88 (~L3600/3755); `ProductDetail.tsx` is touched by no other open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
