### PR TITLE
ux: retire the side-stripe callout idiom (25 sites, 9 files)

### DIFF
--- a/sweet-rebuild-suite-main/src/components/DataQualityBanner.tsx
+++ b/sweet-rebuild-suite-main/src/components/DataQualityBanner.tsx
@@ -80,7 +80,7 @@ export default function DataQualityBanner() {
         initial={{ opacity: 0, y: -8 }}
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0, y: -8 }}
-        className="elevated-card rounded-2xl p-4 border-l-4 border-l-warning relative"
+        className="rounded-2xl p-4 bg-warning/5 border border-warning/20 relative"
       >
         <div className="flex items-start gap-3">
           <AlertTriangle className="w-5 h-5 text-warning shrink-0 mt-0.5" />

--- a/sweet-rebuild-suite-main/src/components/ReportPreviewModal.tsx
+++ b/sweet-rebuild-suite-main/src/components/ReportPreviewModal.tsx
@@ -165,14 +165,14 @@ function SummaryCard({ icon: Icon, label, count, data, color }: {
   color: string;
 }) {
   const colorMap: Record<string, { text: string; bg: string; border: string }> = {
-    emerald: { text: "text-emerald-600", bg: "bg-emerald-500/10", border: "border-l-emerald-500" },
-    blue: { text: "text-blue-600", bg: "bg-blue-500/10", border: "border-l-blue-500" },
-    primary: { text: "text-primary", bg: "bg-primary/10", border: "border-l-primary" },
+    emerald: { text: "text-emerald-600", bg: "bg-emerald-500/10", border: "border-emerald-500/25" },
+    blue: { text: "text-blue-600", bg: "bg-blue-500/10", border: "border-blue-500/25" },
+    primary: { text: "text-primary", bg: "bg-primary/10", border: "border-primary/25" },
   };
   const c = colorMap[color] || colorMap.primary;
 
   return (
-    <div className={`rounded-xl border border-border/30 p-3 border-l-4 ${c.border}`}>
+    <div className={`rounded-xl border p-3 ${c.bg} ${c.border}`}>
       <div className="flex items-center gap-2 mb-2">
         <Icon className={`w-3.5 h-3.5 ${c.text}`} />
         <span className={`text-[10px] font-bold uppercase tracking-wider ${c.text}`}>{label}</span>

--- a/sweet-rebuild-suite-main/src/pages/AIInvoiceImport.tsx
+++ b/sweet-rebuild-suite-main/src/pages/AIInvoiceImport.tsx
@@ -483,7 +483,7 @@ export default function AIInvoiceImport() {
           )}
 
           {allDone && (
-            <div className="elevated-card rounded-2xl p-6 border-l-4 border-l-success text-center">
+            <div className="rounded-2xl p-6 bg-success/5 border border-success/20 text-center">
               <CheckCircle className="w-10 h-10 text-success mx-auto mb-2" />
               <p className="text-[15px] font-semibold text-foreground">
                 {stats.created} created

--- a/sweet-rebuild-suite-main/src/pages/Dashboard.tsx
+++ b/sweet-rebuild-suite-main/src/pages/Dashboard.tsx
@@ -397,12 +397,7 @@ export default function Dashboard() {
           return (
             <motion.div key={card.label} variants={fadeUp}
               title={card.full}
-              className={cn("group relative overflow-hidden stat-card rounded-2xl p-5 space-y-3 border-l-[3px]",
-                card.color === "text-success" ? "border-l-success" :
-                card.color === "text-warning" ? "border-l-warning" :
-                card.color === "text-chart-4" ? "border-l-chart-4" :
-                netAmount >= 0 ? "border-l-success" : "border-l-destructive"
-              )}>
+              className="group relative overflow-hidden stat-card rounded-2xl p-5 space-y-3">
               <div className={cn("absolute -top-8 -right-8 w-32 h-32 rounded-full bg-gradient-radial opacity-0 group-hover:opacity-100 transition-opacity duration-500", card.bgGlow)} />
               <div className="relative flex items-start justify-between">
                 <div className="space-y-1">

--- a/sweet-rebuild-suite-main/src/pages/GSTSummary.tsx
+++ b/sweet-rebuild-suite-main/src/pages/GSTSummary.tsx
@@ -526,7 +526,7 @@ export default function GSTSummary() {
           user hasn't set up yet). */}
       {!isHydrating && carryFwdTotal > 0 && (
         <motion.div initial={{ opacity: 0, y: 4 }} animate={{ opacity: 1, y: 0 }}
-          className="elevated-card rounded-2xl p-3 border-l-4 border-l-success/50 flex items-center gap-3 flex-wrap">
+          className="rounded-2xl p-3 bg-success/5 border border-success/20 flex items-center gap-3 flex-wrap">
           <div className="w-8 h-8 rounded-lg bg-success/10 text-success flex items-center justify-center shrink-0">
             <Clock className="w-4 h-4" />
           </div>
@@ -550,10 +550,10 @@ export default function GSTSummary() {
           While loading, every check shows a neutral "Checking…" rather than
           falsely claiming "no data" before the API resolves. */}
       <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.2 }}
-        className={cn("elevated-card rounded-2xl p-4 border-l-4",
-          readiness.hydrating ? "border-l-muted-foreground/30" :
-          readiness.ready ? "border-l-success" :
-          readiness.passed >= readiness.total - 1 ? "border-l-warning" : "border-l-destructive"
+        className={cn("rounded-2xl p-4 border",
+          readiness.hydrating ? "bg-muted/20 border-border/40" :
+          readiness.ready ? "bg-success/5 border-success/20" :
+          readiness.passed >= readiness.total - 1 ? "bg-warning/5 border-warning/20" : "bg-destructive/5 border-destructive/20"
         )}>
         <div className="flex items-start gap-3 flex-wrap">
           <div className={cn("w-10 h-10 rounded-xl flex items-center justify-center shrink-0",
@@ -604,7 +604,7 @@ export default function GSTSummary() {
 
       {/* GSTR-1 vs GSTR-3B reconciliation banner — only shown when there's a real variance */}
       {reconHasIssue && (
-        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="elevated-card rounded-2xl p-4 border-l-4 border-l-warning">
+        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="rounded-2xl p-4 bg-warning/5 border border-warning/20">
           <div className="flex items-start gap-3">
             <AlertTriangle className="w-5 h-5 text-warning shrink-0 mt-0.5" />
             <div className="flex-1 min-w-0">
@@ -991,7 +991,7 @@ export default function GSTSummary() {
             </div>
 
             {bizFilter === "all" ? (
-              <div className="elevated-card rounded-2xl p-6 border-l-4 border-l-warning">
+              <div className="rounded-2xl p-6 bg-warning/5 border border-warning/20">
                 <div className="flex items-start gap-3">
                   <AlertTriangle className="w-5 h-5 text-warning shrink-0 mt-0.5" />
                   <div>
@@ -1091,7 +1091,7 @@ export default function GSTSummary() {
                     const b = aging.buckets[k];
                     const tone = k === "expired" ? "text-destructive" : k === "fresh" ? "text-warning" : k === "warning" ? "text-chart-3" : "text-success";
                     return (
-                      <div key={k} className={cn("stat-card rounded-2xl p-4 border-l-4", k === "expired" ? "border-l-destructive" : k === "fresh" ? "border-l-warning" : "border-l-border")}>
+                      <div key={k} className="stat-card rounded-2xl p-4">
                         <p className="text-[10px] text-muted-foreground font-medium">{b.label}</p>
                         <p className={cn("font-display font-bold mt-1 text-xl", tone)}>{b.count}</p>
                         <p className="text-[11px] text-muted-foreground mt-0.5">tax {formatCurrency(b.tax)}</p>

--- a/sweet-rebuild-suite-main/src/pages/ImportPreview.tsx
+++ b/sweet-rebuild-suite-main/src/pages/ImportPreview.tsx
@@ -98,7 +98,7 @@ export default function ImportPreview() {
       {/* Outward / Inward / Grand Total Summary */}
       <motion.div variants={fadeUp} className="grid grid-cols-1 lg:grid-cols-3 gap-4">
         {/* Outward */}
-        <div className="elevated-card rounded-2xl p-5 border-l-4 border-l-emerald-500">
+        <div className="elevated-card rounded-2xl p-5">
           <div className="flex items-center gap-2 mb-3">
             <TrendingUp className="w-4 h-4 text-emerald-500" />
             <h3 className="text-xs font-display font-bold uppercase tracking-wider text-emerald-600">Outward Supply</h3>
@@ -114,7 +114,7 @@ export default function ImportPreview() {
         </div>
 
         {/* Inward */}
-        <div className="elevated-card rounded-2xl p-5 border-l-4 border-l-blue-500">
+        <div className="elevated-card rounded-2xl p-5">
           <div className="flex items-center gap-2 mb-3">
             <TrendingDown className="w-4 h-4 text-blue-500" />
             <h3 className="text-xs font-display font-bold uppercase tracking-wider text-blue-600">Inward Supply</h3>
@@ -130,7 +130,7 @@ export default function ImportPreview() {
         </div>
 
         {/* Grand Total */}
-        <div className="elevated-card rounded-2xl p-5 border-l-4 border-l-primary">
+        <div className="elevated-card rounded-2xl p-5">
           <div className="flex items-center gap-2 mb-3">
             <Receipt className="w-4 h-4 text-primary" />
             <h3 className="text-xs font-display font-bold uppercase tracking-wider text-primary">Grand Total</h3>
@@ -148,7 +148,7 @@ export default function ImportPreview() {
 
       {/* Errors (if any) */}
       {result.errors && result.errors.length > 0 && (
-        <motion.div variants={fadeUp} className="elevated-card rounded-2xl p-5 border-l-4 border-l-destructive">
+        <motion.div variants={fadeUp} className="rounded-2xl p-5 bg-destructive/5 border border-destructive/20">
           <h3 className="text-xs font-display font-bold uppercase tracking-wider text-destructive mb-3">Errors ({result.errors.length})</h3>
           <ul className="space-y-1 text-[12px] text-muted-foreground max-h-40 overflow-y-auto">
             {result.errors.map((err, i) => <li key={i} className="flex gap-2"><span className="text-destructive shrink-0">{i + 1}.</span>{err}</li>)}

--- a/sweet-rebuild-suite-main/src/pages/ImportReview.tsx
+++ b/sweet-rebuild-suite-main/src/pages/ImportReview.tsx
@@ -452,19 +452,19 @@ export default function ImportReview() {
 
       {/* Status Summary */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-        <div className="elevated-card rounded-xl p-3 border-l-4 border-l-success">
+        <div className="elevated-card rounded-xl p-3">
           <p className="text-[10px] text-muted-foreground uppercase font-semibold">Ready</p>
           <p className="text-xl font-bold text-success">{readyCount}</p>
         </div>
-        <div className="elevated-card rounded-xl p-3 border-l-4 border-l-blue-500">
+        <div className="elevated-card rounded-xl p-3">
           <p className="text-[10px] text-muted-foreground uppercase font-semibold">New Customers</p>
           <p className="text-xl font-bold text-blue-500">{missingCustCount}</p>
         </div>
-        <div className="elevated-card rounded-xl p-3 border-l-4 border-l-amber-500">
+        <div className="elevated-card rounded-xl p-3">
           <p className="text-[10px] text-muted-foreground uppercase font-semibold">Duplicates</p>
           <p className="text-xl font-bold text-amber-500">{duplicateCount}</p>
         </div>
-        <div className="elevated-card rounded-xl p-3 border-l-4 border-l-destructive">
+        <div className="elevated-card rounded-xl p-3">
           <p className="text-[10px] text-muted-foreground uppercase font-semibold">No Business</p>
           <p className="text-xl font-bold text-destructive">{missingBizCount}</p>
         </div>
@@ -472,7 +472,7 @@ export default function ImportReview() {
 
       {/* Outward/Inward Totals for selected */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
-        <div className="elevated-card rounded-xl p-4 border-l-4 border-l-emerald-500">
+        <div className="elevated-card rounded-xl p-4">
           <div className="flex items-center gap-2 mb-2">
             <TrendingUp className="w-4 h-4 text-emerald-500" />
             <span className="text-[10px] font-bold uppercase tracking-wider text-emerald-600">Outward ({outward.length})</span>
@@ -485,7 +485,7 @@ export default function ImportReview() {
             <div><span className="text-muted-foreground block">Total</span><span className="font-bold text-emerald-600">{fmt(sumInvs(outward).total)}</span></div>
           </div>
         </div>
-        <div className="elevated-card rounded-xl p-4 border-l-4 border-l-blue-500">
+        <div className="elevated-card rounded-xl p-4">
           <div className="flex items-center gap-2 mb-2">
             <TrendingDown className="w-4 h-4 text-blue-500" />
             <span className="text-[10px] font-bold uppercase tracking-wider text-blue-600">Inward ({inward.length})</span>

--- a/sweet-rebuild-suite-main/src/pages/InvoiceDetail.tsx
+++ b/sweet-rebuild-suite-main/src/pages/InvoiceDetail.tsx
@@ -140,7 +140,7 @@ export default function InvoiceDetail() {
     return (
       <div className={cn("space-y-5 animate-fade-in", isMobile ? "p-4 pb-24" : "p-6 lg:p-8 max-w-3xl mx-auto")}>
         <Breadcrumbs items={[{ label: "Invoices", href: "/billing/invoice/list" }, { label: slug || "Invoice" }]} />
-        <div className="elevated-card rounded-2xl p-5 border-l-4 border-l-warning flex items-start gap-3">
+        <div className="rounded-2xl p-5 bg-warning/5 border border-warning/20 flex items-start gap-3">
           <AlertTriangle className="w-5 h-5 text-warning shrink-0 mt-0.5" />
           <div className="flex-1">
             <p className="text-[14px] font-semibold text-foreground">Multiple invoices share number "{slug}"</p>

--- a/sweet-rebuild-suite-main/src/pages/InvoiceList.tsx
+++ b/sweet-rebuild-suite-main/src/pages/InvoiceList.tsx
@@ -396,7 +396,7 @@ export default function InvoiceList() {
           drill-down, make it explicit *why* the list looks short, and give a
           one-click escape hatch back to the unfiltered view. */}
       {hygieneFilterLabel && (
-        <div className="elevated-card rounded-2xl p-3.5 border-l-4 border-l-warning flex items-center gap-3">
+        <div className="rounded-2xl p-3.5 bg-warning/5 border border-warning/20 flex items-center gap-3">
           <SlidersHorizontal className="w-4 h-4 text-warning shrink-0" />
           <div className="flex-1 min-w-0">
             <p className="text-[13px] font-semibold text-foreground">Filtered: {hygieneFilterLabel}</p>


### PR DESCRIPTION
The design detector's top finding: elevated-card + border-l-4 was the
one idiom repeated everywhere a status needed announcing. Two
replacements, chosen per role:

- status banners/callouts (12 sites) become tinted-wash panels
  (bg-{hue}/5 + border-{hue}/20) -- the treatment ProductForm's usage
  card already established, and which passed the 177-sample contrast
  sweep in all five themes
- stat tiles whose numbers/icons already carry the hue (13 sites) just
  drop the stripe; the color was saying the same thing twice

Deliberately untouched: QRScanner's viewfinder corners/scan-line
(functional camera UI, not decoration), ImportPage's border-l-2
selected-row indicator (a selection affordance), and shadcn's
scroll-area internals. The audit's "gradient text" and index.css
font-stretch items no longer exist in the tree.

Verified: tsc clean (ship blobs, not just the local tree), 51 vitest,
Dashboard + GST Summary readiness card eyeballed live in dark mode.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>