### PR TITLE
Recover #91: server-side preferences never landed on main (stranded stacked merge)

### DIFF
--- a/billing/api/preferences.py
+++ b/billing/api/preferences.py
@@ -1,0 +1,37 @@
+"""Per-user preferences: GET returns the blob, PATCH shallow-merges into it.
+
+Lives in its own module (not views.py) so the endpoint never collides with
+the several in-flight branches that edit views.py.
+"""
+
+import json
+
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from billing.models import UserPreference
+
+# One JSON blob per user; 8 KB is ~40x what the Settings page stores today —
+# a typo'd client can't turn this into unbounded storage.
+MAX_BYTES = 8192
+
+
+class PreferencesView(APIView):
+    def get(self, request):
+        pref = UserPreference.objects.filter(user=request.user).first()
+        return Response({"data": pref.data if pref else {}})
+
+    def patch(self, request):
+        incoming = request.data
+        if not isinstance(incoming, dict):
+            return Response({"error": "preferences must be a JSON object"}, status=400)
+        pref, _ = UserPreference.objects.get_or_create(user=request.user)
+        merged = {**pref.data, **incoming}
+        # A key set to null means "remove" — lets the client un-set without
+        # a separate DELETE shape.
+        merged = {k: v for k, v in merged.items() if v is not None}
+        if len(json.dumps(merged)) > MAX_BYTES:
+            return Response({"error": "preferences too large"}, status=400)
+        pref.data = merged
+        pref.save(update_fields=["data", "updated_at"])
+        return Response({"data": pref.data})

--- a/billing/api/urls.py
+++ b/billing/api/urls.py
@@ -28,6 +28,7 @@ from .views import (
     ReportView,
     UserManagementView,
 )
+from .preferences import PreferencesView
 
 router = DefaultRouter()
 router.register(r"businesses", BusinessViewSet)
@@ -67,6 +68,7 @@ urlpatterns = [
     # Profile & User Management
     path("profile/", ProfileView.as_view(), name="profile"),
     path("users/", UserManagementView.as_view(), name="user-management"),
+    path("preferences/", PreferencesView.as_view(), name="preferences"),
     # JWT Authentication endpoints
     path("token/", TokenObtainPairView.as_view(serializer_class=CustomTokenObtainPairSerializer), name="token_obtain_pair"),
     path("token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),

--- a/billing/migrations/0035_user_preference.py
+++ b/billing/migrations/0035_user_preference.py
@@ -1,0 +1,25 @@
+# Per-user preferences blob — the Settings page roams instead of living in
+# one browser's localStorage.
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("billing", "0034_product_default_unit"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="UserPreference",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("data", models.JSONField(blank=True, default=dict)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("user", models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, related_name="preference", to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/billing/models.py
+++ b/billing/models.py
@@ -687,6 +687,26 @@ class Product(AbstractBaseModel):
     )
 
 
+class UserPreference(models.Model):
+    """Per-user app preferences (default business, invoice defaults, UI
+    toggles), stored as one JSON blob so the Settings page roams across
+    devices instead of living in one browser's localStorage.
+
+    Shape is owned by the frontend; the API only enforces that it stays a
+    reasonably-sized JSON object. Device-local concerns (theme, mobile mode)
+    deliberately stay in localStorage.
+    """
+
+    user = models.OneToOneField(
+        "auth.User", on_delete=models.CASCADE, related_name="preference"
+    )
+    data = models.JSONField(default=dict, blank=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    def __str__(self):
+        return f"preferences<{self.user.username}>"
+
+
 class AuditLog(models.Model):
     ACTION_CHOICES = [
         ("created", "Created"),

--- a/billing/tests/test_preferences_api.py
+++ b/billing/tests/test_preferences_api.py
@@ -1,0 +1,50 @@
+"""/api/preferences/ — per-user settings blob so Settings roams across devices."""
+
+from django.contrib.auth.models import User
+from django.urls import reverse
+
+from billing.models import UserPreference
+from billing.tests.test_base import BaseAPITestCase
+
+
+class PreferencesAPITest(BaseAPITestCase):
+    def test_empty_by_default(self):
+        resp = self.client.get(reverse("preferences"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["data"], {})
+
+    def test_patch_merges_shallowly(self):
+        self.client.patch(reverse("preferences"), {"defaultBusinessId": "3"}, format="json")
+        resp = self.client.patch(reverse("preferences"), {"defaultGstRate": 3}, format="json")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp.data["data"], {"defaultBusinessId": "3", "defaultGstRate": 3}
+        )
+
+    def test_null_removes_a_key(self):
+        self.client.patch(reverse("preferences"), {"showHSN": True}, format="json")
+        resp = self.client.patch(reverse("preferences"), {"showHSN": None}, format="json")
+        self.assertEqual(resp.data["data"], {})
+
+    def test_rejects_non_object_and_oversize(self):
+        resp = self.client.patch(reverse("preferences"), ["not", "an", "object"], format="json")
+        self.assertEqual(resp.status_code, 400)
+        resp = self.client.patch(
+            reverse("preferences"), {"blob": "x" * 9000}, format="json"
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("too large", resp.data["error"])
+
+    def test_isolated_per_user(self):
+        self.client.patch(reverse("preferences"), {"invoicePrefix": "SGJ"}, format="json")
+        other = User.objects.create_user(username="other", password="x")
+        self.client.force_authenticate(user=other)
+        resp = self.client.get(reverse("preferences"))
+        self.assertEqual(resp.data["data"], {})
+        self.assertEqual(UserPreference.objects.count(), 1)
+
+    def test_requires_auth(self):
+        self.client.force_authenticate(user=None)
+        self.assertIn(
+            self.client.get(reverse("preferences")).status_code, (401, 403)
+        )

--- a/sweet-rebuild-suite-main/src/hooks/usePreferences.ts
+++ b/sweet-rebuild-suite-main/src/hooks/usePreferences.ts
@@ -1,0 +1,57 @@
+import api from "@/utils/api";
+
+/**
+ * Per-user preferences, persisted server-side (/api/preferences/) so the
+ * Settings page roams across devices, with localStorage as the offline
+ * mirror. Device-local concerns (theme, mobile mode) stay in their own
+ * localStorage keys on purpose.
+ */
+
+export const SETTINGS_STORAGE_KEY = "gst_app_settings";
+
+let cache: Record<string, any> | null = null;
+let inflight: Promise<Record<string, any>> | null = null;
+
+function readMirror(): Record<string, any> {
+  try {
+    const raw = localStorage.getItem(SETTINGS_STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeMirror(data: Record<string, any>) {
+  try {
+    localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(data));
+  } catch {
+    // storage full or unavailable — server copy is authoritative anyway
+  }
+}
+
+/** Server copy, memoized per page load; falls back to the local mirror offline. */
+export function fetchPreferences(): Promise<Record<string, any>> {
+  if (cache) return Promise.resolve(cache);
+  if (!inflight) {
+    inflight = api
+      .get("preferences/")
+      .then((res) => {
+        cache = res.data?.data || {};
+        writeMirror(cache!);
+        return cache!;
+      })
+      .catch(() => {
+        inflight = null; // retry on next call
+        return readMirror();
+      });
+  }
+  return inflight;
+}
+
+/** Shallow-merge a patch server-side; null values remove keys. */
+export async function patchPreferences(patch: Record<string, any>): Promise<Record<string, any>> {
+  const res = await api.patch("preferences/", patch);
+  cache = res.data?.data || {};
+  writeMirror(cache!);
+  return cache!;
+}

--- a/sweet-rebuild-suite-main/src/pages/InvoiceForm.tsx
+++ b/sweet-rebuild-suite-main/src/pages/InvoiceForm.tsx
@@ -207,6 +207,22 @@ export default function InvoiceForm({ mode }: InvoiceFormProps) {
 
   const DRAFT_KEY = "gst_invoice_draft";
 
+  // Settings' "Default Business" finally does something: preselect it on a
+  // fresh create (never over a draft, duplicate, or a choice already made).
+  useEffect(() => {
+    if (mode !== "create" || duplicateFrom || form.businessId) return;
+    let alive = true;
+    import("@/hooks/usePreferences").then(({ fetchPreferences }) =>
+      fetchPreferences().then((prefs) => {
+        const preferred = String(prefs?.defaultBusinessId || "");
+        if (!alive || !preferred) return;
+        setForm((p) => (p.businessId ? p : { ...p, businessId: preferred }));
+      })
+    );
+    return () => { alive = false; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, duplicateFrom]);
+
   // Check for saved draft on mount (create mode only)
   useEffect(() => {
     if (mode !== "create" || duplicateFrom) return;

--- a/sweet-rebuild-suite-main/src/pages/Settings.tsx
+++ b/sweet-rebuild-suite-main/src/pages/Settings.tsx
@@ -14,7 +14,7 @@ import { Switch } from "@/components/ui/switch";
 import { resetOnboarding } from "@/components/OnboardingWizard";
 // Invoice template removed — Tally format is the standard
 
-const SETTINGS_STORAGE_KEY = "gst_app_settings";
+import { fetchPreferences, patchPreferences, SETTINGS_STORAGE_KEY } from "@/hooks/usePreferences";
 
 function getCurrentFinancialYear(): string {
   const now = new Date();
@@ -55,6 +55,18 @@ export default function Settings() {
   const { mobileMode, setMobileMode } = useMobileMode();
   const { items: businesses } = useBusinesses();
   const [settings, setSettings] = useState(() => loadSettings(businesses[0]?.id || ""));
+
+  // Server copy wins over the localStorage mirror once it arrives, so the
+  // same preferences follow the user to any device.
+  useEffect(() => {
+    let alive = true;
+    fetchPreferences().then((server) => {
+      if (alive && server && Object.keys(server).length > 0) {
+        setSettings((p) => ({ ...p, ...server }));
+      }
+    });
+    return () => { alive = false; };
+  }, []);
   const [nextInvoiceInfo, setNextInvoiceInfo] = useState<string>("");
   // `dirty` tracks whether any field has changed since the last save.
   // Drives the save bar's enabled state + label, so the sticky button isn't
@@ -93,14 +105,17 @@ export default function Settings() {
     setSettings((p) => ({ ...p, [field]: val }));
     setDirty(true);
   };
-  const handleSave = () => {
+  const handleSave = async () => {
     try {
-      localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(settings));
+      await patchPreferences(settings);
+      setDirty(false);
+      toast({ title: "Settings Saved", description: "Saved to your account — they follow you to any device." });
     } catch {
-      // storage full or unavailable
+      // Offline or server hiccup: keep the local mirror so nothing is lost.
+      try { localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(settings)); } catch { /* ignore */ }
+      setDirty(false);
+      toast({ title: "Saved locally", description: "Could not reach the server — will apply on this device.", variant: "destructive" });
     }
-    setDirty(false);
-    toast({ title: "Settings Saved", description: "Your preferences have been updated." });
   };
 
   const sections = [
@@ -232,15 +247,17 @@ export default function Settings() {
       fields: (
         <div className="flex items-center justify-between p-3 rounded-xl bg-destructive/5 border border-destructive/15">
           <div>
-            <p className="text-[13px] font-semibold text-foreground">Clear Local Settings</p>
-            <p className="text-[11px] text-muted-foreground mt-0.5">Reset all preferences to defaults. Doesn't delete server data — just your local browser config.</p>
+            <p className="text-[13px] font-semibold text-foreground">Reset Preferences</p>
+            <p className="text-[11px] text-muted-foreground mt-0.5">Reset your saved preferences to defaults, on this device and your account. Business data is untouched.</p>
           </div>
-          <button onClick={() => {
-            if (!confirm("Clear all local settings and reset to defaults? This affects only your browser, not server data.")) return;
+          <button onClick={async () => {
+            if (!confirm("Reset all preferences to defaults? Business data is untouched.")) return;
             localStorage.removeItem(SETTINGS_STORAGE_KEY);
-            setSettings(loadSettings(businesses[0]?.id || ""));
+            const defaults = loadSettings(businesses[0]?.id || "");
+            setSettings(defaults);
             setDirty(false);
-            toast({ title: "Settings Cleared", description: "Preferences reset to defaults.", variant: "destructive" });
+            try { await patchPreferences(Object.fromEntries(Object.keys(defaults).map((k) => [k, null]))); } catch { /* offline — mirror already cleared */ }
+            toast({ title: "Preferences Reset", description: "Back to defaults.", variant: "destructive" });
           }}
             className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-destructive/10 text-destructive hover:bg-destructive/20 transition-colors flex items-center gap-1.5 shrink-0">
             <Trash2 className="w-3.5 h-3.5" /> Clear


### PR DESCRIPTION
## Why this PR exists

**#91 shows "Merged" but its content never reached `main`.** When it was merged, its base still pointed at `feat/product-default-unit` (the branch hadn't been deleted yet, so GitHub never retargeted it) — so the merge landed **on that branch**, and the follow-up #99 was cut from a *different* branch that didn't contain it. Same trap that #98/#99 already had to fix for #87/#86 — this is the last stranded piece.

**What's missing from main right now:** the `UserPreference` model + migration 0035, `GET/PATCH /api/preferences/`, the `usePreferences` hook, the Settings server-sync, and the Default-Business preselect in InvoiceForm.

## Proof it's safe

This branch merged into current `main` produces git tree **`35fd65b7…`** — **byte-for-byte identical** to the integration preflight tree that already passed the full battery:

- 188 backend tests · fresh-DB migrate 0033→0034→0035 · `makemigrations --check` clean
- tsc 0 errors · 51 vitest · production build · `npm ci`
- **18/18 live Playwright E2E** · cross-PR API checks (preferences round-trip, default_unit, hsn_usage, GSTIN, SPA fallback)
- `production_settings` boots with Sentry on and off · **CircleCI green on this exact tree (PG16)**

Nothing new to test — this is the already-verified end state, minus nothing.

## After merging

This triggers one more Docker Publish. Deploy after **that** build (the current image from 14:56 lacks preferences), then migrations 0033→0035 apply on `up -d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
