### PR TITLE
ops: tag-based releases + Watchtower auto-deploy (tag a commit, server updates itself)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,20 +1,54 @@
-name: Docker Publish
+name: Release
+
+# Tag-based releases: images are built ONLY when a version tag is pushed
+# (git tag v2.0.0 && git push origin v2.0.0, or a GitHub Release). Merging
+# to main runs Tests but publishes nothing — you choose when prod changes.
+# On the server, Watchtower (see docker-compose.yml) sees the new :latest
+# within a minute and redeploys automatically; the versioned tag stays on
+# Docker Hub for rollback.
+#
+# workflow_dispatch is the manual escape hatch: it builds whatever ref you
+# run it from and tags the images :latest + :<ref-name>.
 
 on:
   push:
-    branches:
-      - main
-      - new_ui
-    paths-ignore:
-      - '**.md'
-      - '.gitignore'
+    tags:
+      - "v*"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Never cancel a release mid-push — a half-published pair of images
+  # (new backend, old nginx) is worse than a slightly slower queue.
+  cancel-in-progress: false
 
 jobs:
+  test:
+    # Release gate: the fast backend suite. E2E already gated every PR on
+    # its way into main; this catches a bad tag (wrong commit, stale branch).
+    name: Backend tests (release gate)
+    runs-on: ubuntu-24.04
+    env:
+      DJANGO_SETTINGS_MODULE: gst_billing.test_settings
+      DJANGO_SECRET_KEY: ci-test-key-not-secret
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install uv
+        run: pip install uv
+      - name: Install dependencies
+        run: |
+          uv venv
+          uv pip install . pytest pytest-django gunicorn 'setuptools<81'
+      - name: Run tests
+        run: |
+          source .venv/bin/activate
+          pytest billing/ -x --tb=short
+
   build-and-push:
+    needs: test
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -48,8 +82,10 @@ jobs:
           file: ${{ matrix.file }}
           push: true
           platforms: linux/amd64,linux/arm64
+          # :latest is what the server tracks; :vX.Y.Z (the git tag name) is
+          # the immutable handle you roll back to.
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/${{ matrix.image }}:latest
-            ${{ secrets.DOCKER_USERNAME }}/${{ matrix.image }}:${{ github.sha }}
+            ${{ secrets.DOCKER_USERNAME }}/${{ matrix.image }}:${{ github.ref_name }}
           cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/${{ matrix.image }}:buildcache
           cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/${{ matrix.image }}:buildcache,mode=max

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -71,6 +71,9 @@ chmod +x deploy.sh
 ./deploy.sh
 ```
 
+This first `up -d` also starts **Watchtower**, after which day-to-day deploys
+are automatic — see [Releases and automatic deployment](#releases-and-automatic-deployment).
+
 ### 6. Set Up SSL (Optional but Recommended)
 
 #### Using Let's Encrypt:
@@ -432,3 +435,67 @@ For better performance:
    ```
 
    Add performance tuning parameters and update docker-compose.yml to mount this configuration.
+
+## Releases and automatic deployment
+
+Deploys are **tag-driven**. Merging PRs changes `main` (and runs Tests) but
+does not touch production; production changes when you cut a release.
+
+### Cut a release
+
+```bash
+git tag -a v2.0.0 -m "everything since the May image"
+git push origin v2.0.0
+```
+
+(Equivalently: GitHub → Releases → *Draft a new release* → create the tag
+there — publishing the release pushes the tag.)
+
+That tag triggers the **Release** workflow:
+
+1. the backend test suite runs as a gate (a bad tag never builds),
+2. both images build for amd64+arm64 and push to Docker Hub as
+   `:latest` **and** `:v2.0.0`.
+
+### What the server does (nothing, automatically)
+
+`docker compose up -d` runs a **Watchtower** container that polls Docker Hub
+every 60 seconds. When a release lands, it pulls the new `:latest`, recreates
+`web` and `nginx` (only those two — they're label-scoped), and prunes the old
+images. The `web` container's start command runs `migrate`, so database
+migrations apply exactly as they did under manual deploys. End to end: a tag
+push is live in production about 5–10 minutes later (mostly build time).
+
+Watch it happen:
+
+```bash
+docker compose logs -f watchtower
+```
+
+### Roll back
+
+Every release keeps its immutable version tag on Docker Hub. To roll back,
+pin the compose file to the last good version and restart:
+
+```yaml
+# docker-compose.yml (temporarily)
+web:
+  image: vaibhav198/gst-billing:v1.9.0
+nginx:
+  image: vaibhav198/gst-billing-nginx:v1.9.0
+```
+
+```bash
+docker compose up -d web nginx
+```
+
+Watchtower only tracks the tag a container was started from, so a container
+pinned to `v1.9.0` stays put until you switch it back to `:latest`.
+(Remember migrations don't auto-reverse — rolling back past a migration needs
+a manual `manage.py migrate billing <previous>` first.)
+
+### Manual escape hatch
+
+The Release workflow also has a **Run workflow** button (`workflow_dispatch`)
+— it builds whatever ref you point it at and tags the images
+`:latest` + `:<ref-name>`, for the rare "rebuild without a new tag" case.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,10 @@ services:
   web:
     image: vaibhav198/gst-billing:latest
     restart: unless-stopped
+    labels:
+      # Watchtower redeploys this service when a new :latest lands on
+      # Docker Hub (published only by the tag-triggered Release workflow).
+      - com.centurylinklabs.watchtower.enable=true
     volumes:
       - gst_static_volume:/app/staticfiles
       - gst_media_volume:/app/media
@@ -38,6 +42,8 @@ services:
     # Uses the image built via Github Actions
     image: vaibhav198/gst-billing-nginx:latest
     restart: unless-stopped
+    labels:
+      - com.centurylinklabs.watchtower.enable=true
     ports:
       # Map to a port Cosmos can reverse proxy (e.g. 8060)
       - "8060:80"
@@ -46,3 +52,18 @@ services:
       - gst_media_volume:/var/www/media:ro
     depends_on:
       - web
+
+  # Auto-deploy: polls Docker Hub every 60s and recreates ONLY the services
+  # labeled watchtower.enable=true (web + nginx) when their :latest changes —
+  # redis and anything else on the box are never touched (--label-enable).
+  # The web container's own start command runs migrate, so a new release
+  # applies its migrations exactly like a manual `compose pull && up -d` did.
+  # --cleanup prunes the superseded images so the disk doesn't fill up.
+  # Note: mounting docker.sock gives this container Docker-level (root)
+  # control of the host — standard for Watchtower; it runs no exposed ports.
+  watchtower:
+    image: containrrr/watchtower
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: --label-enable --cleanup --interval 60


### PR DESCRIPTION
## What

Exactly the flow you described: **tag a commit → image builds → server deploys itself.** No more building on every merge, no more SSH-in-and-pull.

### Build side — `docker-publish.yml` becomes **Release**

- Triggers **only on version tags** (`v*`) — cut a release with:
  ```
  git tag -a v2.0.0 -m "everything since the May image"
  git push origin v2.0.0
  ```
  or via GitHub → Releases → *Draft a new release* (creating the tag there works identically).
- **Test-gated**: the backend suite runs first; a bad tag never builds.
- Pushes both images as `:latest` **and** `:vX.Y.Z` (multi-arch, same registry cache) — the version tag is your immutable rollback handle.
- Merges to main now run Tests only and publish nothing. `workflow_dispatch` remains as a manual rebuild button.
- Reuses the existing `DOCKER_USERNAME`/`DOCKER_PASSWORD` secrets — nothing new to configure in GitHub.

### Deploy side — Watchtower in `docker-compose.yml`

The "server listens for the new tag" part, pull-based (no SSH keys in GitHub, no inbound ports):

- A `watchtower` service polls Docker Hub every **60s** and recreates **only** `web` + `nginx` (label-scoped via `--label-enable`; redis is never touched) when `:latest` changes, then prunes the superseded images (`--cleanup`) so the disk doesn't fill.
- Migrations keep working exactly as today: the `web` container's start command runs `migrate` on every (re)start.
- The one honest caveat is in a comment: mounting `docker.sock` gives Watchtower Docker-level control of the host — the standard trade-off for this pattern; it exposes no ports.

### Docs

`DEPLOYMENT.md` gains a **Releases and automatic deployment** section: the release command, the ~5–10 min tag-to-live timeline, `docker compose logs -f watchtower` to watch it, **rollback** (pin the compose image to the last good `vX.Y.Z`; Watchtower won't fight a pinned tag), and the migrate-doesn't-auto-reverse caveat.

## After merging — one-time server step

```bash
cd ~/gst && git pull   # or copy the updated docker-compose.yml
docker compose up -d   # starts watchtower alongside the stack
```

Then cut **v2.0.0** and watch it deploy itself. Every deploy after that is just a tag.

## Notes

- Base `main`; no other open PR touches these three files.
- Suggest starting the series at `v2.0.0` — it's the V2-era codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
