### PR TITLE
fix: GST page outward card honours the month filter; report gets a real NET row

### DIFF
--- a/billing/api/views.py
+++ b/billing/api/views.py
@@ -2479,7 +2479,10 @@ class ReportView(APIView):
                 ]
             )
 
-        # Grand Total (Outward + Inward combined)
+        # NET row (Outward − Inward). This used to ADD sales to purchases —
+        # a figure that means nothing and that the CA review flagged (D7).
+        # Outward − inward is the real position: sales margin on value, and
+        # output tax − ITC on the tax columns (the GSTR-3B shape).
         if invoice_type == "both" and (
             totals["outward_taxable"] or totals["inward_taxable"]
         ):
@@ -2487,16 +2490,16 @@ class ReportView(APIView):
             sheet.append(
                 [""] * 5
                 + [
-                    f"GRAND TOTAL ({date_range_str})",
+                    f"NET (OUTWARD − INWARD) ({date_range_str})",
                     "",
                     "",
                     "",
                     "",
-                    totals["outward_taxable"] + totals["inward_taxable"],
-                    totals["outward_cgst"] + totals["inward_cgst"],
-                    totals["outward_sgst"] + totals["inward_sgst"],
-                    totals["outward_igst"] + totals["inward_igst"],
-                    totals["outward_total"] + totals["inward_total"],
+                    totals["outward_taxable"] - totals["inward_taxable"],
+                    totals["outward_cgst"] - totals["inward_cgst"],
+                    totals["outward_sgst"] - totals["inward_sgst"],
+                    totals["outward_igst"] - totals["inward_igst"],
+                    totals["outward_total"] - totals["inward_total"],
                 ]
             )
 

--- a/billing/tests/test_report_view.py
+++ b/billing/tests/test_report_view.py
@@ -125,3 +125,36 @@ class ReportViewTestCase(BaseAPITestCase):
         # Verify the invoice IDs are included
         self.assertTrue(any(item[15] == self.outward_invoice.id for item in line_items))
         self.assertTrue(any(item[15] == self.inward_invoice.id for item in line_items))
+
+
+    def test_both_report_net_row_subtracts_inward_from_outward(self):
+        """The combined row is NET (outward − inward) — it used to ADD sales
+        to purchases, which the CA review flagged as meaningless (D7)."""
+        import io
+
+        from openpyxl import load_workbook
+
+        today = datetime.now().date()
+        data = {
+            "start_date": (today - timedelta(days=7)).strftime("%Y-%m-%d"),
+            "end_date": (today + timedelta(days=1)).strftime("%Y-%m-%d"),
+            "invoice_type": "both",
+        }
+        response = self.client.post(reverse("generate-report"), data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        wb = load_workbook(io.BytesIO(response.content), data_only=True)
+        sheet = wb["Test Business Report"]
+
+        net_rows = [
+            row for row in sheet.iter_rows(values_only=True)
+            if any(isinstance(c, str) and c.startswith("NET (OUTWARD") for c in row)
+        ]
+        self.assertEqual(len(net_rows), 1, "exactly one NET row expected")
+        row = net_rows[0]
+        # Fixture: outward 10×100, inward 5×100 → net taxable 500.
+        self.assertEqual(float(row[10]), 500.0)
+        # And no additive GRAND TOTAL row survives anywhere.
+        for r in sheet.iter_rows(values_only=True):
+            for c in r:
+                if isinstance(c, str):
+                    self.assertFalse(c.startswith("GRAND TOTAL"), f"additive row still present: {c}")

--- a/sweet-rebuild-suite-main/src/pages/GSTSummary.tsx
+++ b/sweet-rebuild-suite-main/src/pages/GSTSummary.tsx
@@ -220,7 +220,14 @@ export default function GSTSummary() {
     .sort((a: any, b: any) => Number(a.rate) - Number(b.rate));
   const hsnRows = gstData?.hsn_summary || [];
   const gstr3b = gstData?.gstr3b || { output_tax: { cgst: 0, sgst: 0, igst: 0, total: 0 }, input_tax_credit: { cgst: 0, sgst: 0, igst: 0, total: 0 }, net_payable: { cgst: 0, sgst: 0, igst: 0, total: 0 } };
-  const totalOutward = statsData?.totals?.outward || 0;
+  // Outward Supply must honour the month/range filter like every other card
+  // on this row. statsData is FY-scoped (it fed this card ₹24.3L on an empty
+  // February); the gst_summary payload is period-scoped and its outward
+  // slabs' `total` is gross sales+tax — exactly this card's number.
+  const periodScoped = useCustomRange || selectedMonth !== "All";
+  const totalOutward = periodScoped
+    ? (gstData?.rate_slabs?.outward || []).reduce((s: number, r: any) => s + Number(r.total || 0), 0)
+    : statsData?.totals?.outward || 0;
   const totalOutwardTax = gstr3b.output_tax.total;
   const totalITC = gstr3b.input_tax_credit.total;
   // Carry-forward (opening) ITC from previous FY, surfaced at top-level on


### PR DESCRIPTION
## Two bugs, one page and one workbook — both from today's CA review + screenshots

**1. Outward Supply ignored the month filter.** Every other card on the GST page row is period-scoped (they read the `gst_summary` payload); Outward Supply alone read FY-scoped stats — so an **empty February showed the full year's ₹24.30L**. It now sums the period-scoped outward rate-slabs' gross totals whenever a month or custom range is active, and keeps the FY stats total on "All". Verified live on a seeded fixture: FY view ₹15.4k → July ₹10.3k → February ₹0.

**2. The report's combined row added sales to purchases** (CA finding **D7** — "adding sales to purchases is not a meaningful figure"). The `GRAND TOTAL (Outward + Inward)` row is now **`NET (OUTWARD − INWARD)`**: margin on the value column, output-tax-minus-ITC on the tax columns — the GSTR-3B shape. A new test parses the actual generated workbook and asserts the row *subtracts* (fixture: 1,000 outward − 500 inward = 500) and that no additive row survives anywhere in the sheet.

**CA finding D1 needed no code**: the "Taxable Value = taxable+tax" rows were the qty-0 GSTR-2A-era lines, healed in tonight's prod data batch (qty→1, rate→taxable); the current 2A importer already writes qty=1.

## Verified

184 backend tests (incl. the new workbook-parsing test) · tsc + 51 vitest · card behaviour eyeballed live in all three states · ship blobs byte-identical to the tested local files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)