### PR TITLE
Security + ops: signed media, login rate limits, CSP, nightly backups, /healthz

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,18 @@ on:
     branches: [main]
 
 jobs:
+  nginx-config:
+    # A broken conf would brick the nginx container on Watchtower's next
+    # auto-deploy — validate it the way nginx itself will read it.
+    name: nginx config validates
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: nginx -t against the shipped conf.d
+        run: |
+          docker run --rm -v "$PWD/nginx/conf.d":/etc/nginx/conf.d:ro nginx:alpine \
+            sh -c "mkdir -p /var/www/static /var/www/media /usr/share/nginx/html && nginx -t"
+
   backend:
     name: Backend (pytest)
     runs-on: ubuntu-24.04

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -499,3 +499,47 @@ a manual `manage.py migrate billing <previous>` first.)
 The Release workflow also has a **Run workflow** button (`workflow_dispatch`)
 — it builds whatever ref you point it at and tags the images
 `:latest` + `:<ref-name>`, for the rare "rebuild without a new tag" case.
+
+## Backups
+
+A `backup` sidecar (postgres:16-alpine, **not** watchtower-labeled) runs
+`deploy/backup/backup.sh`: on start and every 24h it takes
+
+- `pg_dump --format=custom` of the app database (`db-<stamp>.dump`), verified
+  with `pg_restore --list`, and
+- a tar of the media volume (`media-<stamp>.tar.gz`)
+
+into `./backups` on the host, deleting files older than 30 days. First run:
+
+```bash
+mkdir -p backups && docker compose up -d backup && docker compose logs -f backup
+```
+
+**Off-site copy**: `./backups` lives on the same disk as everything else.
+Sync it somewhere else (cron + rclone/rsync, or your provider's snapshot
+feature) — a backup on the failed disk is not a backup.
+
+### Restore drill (do this once now, not during an outage)
+
+```bash
+docker compose exec backup sh
+pg_restore --list /backups/db-<stamp>.dump | head    # archive is readable
+createdb  -h "$DB_HOST" -U "$DB_USER" restore_drill
+pg_restore -h "$DB_HOST" -U "$DB_USER" -d restore_drill --no-owner /backups/db-<stamp>.dump
+psql -h "$DB_HOST" -U "$DB_USER" -d restore_drill -c 'SELECT COUNT(*) FROM billing_invoice;'
+dropdb    -h "$DB_HOST" -U "$DB_USER" restore_drill
+```
+
+Media check: `tar -tzf /backups/media-<stamp>.tar.gz | head`.
+
+## Health checks and alerts
+
+`GET /healthz` (no auth) answers `200 {"ok": true, "db": true}` when Django
+can reach the database, `503` otherwise. Point a free uptime monitor
+(UptimeRobot, Better Stack, …) at `https://<your-domain>/healthz` and you'll
+hear about outages before anyone else does.
+
+Deploy notifications: set `WATCHTOWER_NOTIFICATION_URL` in `.env` using any
+[shoutrrr](https://containrrr.dev/shoutrrr/) URL — e.g.
+`telegram://<bot-token>@telegram?chats=<chat-id>` — and Watchtower announces
+every image update (and failed pull). Leave it unset for silence.

--- a/billing/api/media.py
+++ b/billing/api/media.py
@@ -1,0 +1,82 @@
+"""Signed, expiring media URLs — the auth layer for uploaded bill scans.
+
+Why signatures instead of the JWT header: media is consumed by <img> and
+<iframe> tags, which cannot attach Authorization headers. The URL itself is
+therefore the credential — an HMAC over the file path with a timestamp,
+minted only inside authenticated API responses and valid for a few hours.
+
+In production nginx does the actual file streaming: this view validates the
+signature and answers with X-Accel-Redirect to an `internal` location, so
+Django never proxies bytes. In development and tests (no nginx in front)
+it streams the file itself.
+"""
+
+import mimetypes
+import posixpath
+from urllib.parse import quote
+
+from django.conf import settings
+from django.core.signing import BadSignature, SignatureExpired, TimestampSigner
+from django.http import FileResponse, HttpResponse, HttpResponseForbidden
+from rest_framework.permissions import AllowAny
+from rest_framework.views import APIView
+
+_signer = TimestampSigner(salt="billing.media")
+
+# How long a minted URL stays valid. API responses are consumed immediately
+# and re-fetched on every page visit, so hours is generous.
+MAX_AGE_SECONDS = 6 * 60 * 60
+
+
+def sign_media_path(name: str) -> str:
+    """Storage-relative file name → same-origin signed URL.
+
+    Relative on purpose (see serializers._abs): the SPA is same-origin with
+    the API everywhere, and absolute URLs would be built from the proxied
+    plain-http request and get blocked as mixed content.
+    """
+    token = _signer.sign(name)
+    return f"/api/media/{quote(name)}?s={quote(token)}"
+
+
+class SignedMediaView(APIView):
+    # The signature IS the credential — this must work for bare <img>/<iframe>
+    # requests that carry neither JWT header nor session cookie.
+    permission_classes = [AllowAny]
+    authentication_classes = []
+
+    def get(self, request, subpath: str):
+        token = request.query_params.get("s", "")
+        try:
+            signed_name = _signer.unsign(token, max_age=MAX_AGE_SECONDS)
+        except SignatureExpired:
+            return HttpResponseForbidden("Link expired — reload the page for a fresh one.")
+        except BadSignature:
+            return HttpResponseForbidden("Invalid media signature.")
+
+        # The path in the URL must be exactly the path that was signed, and
+        # normalised it must stay inside MEDIA_ROOT.
+        if signed_name != subpath:
+            return HttpResponseForbidden("Signature does not match this file.")
+        normalized = posixpath.normpath(subpath)
+        if normalized != subpath or subpath.startswith(("/", "../")) or ".." in subpath.split("/"):
+            return HttpResponseForbidden("Invalid media path.")
+
+        content_type = mimetypes.guess_type(subpath)[0] or "application/octet-stream"
+
+        if getattr(settings, "MEDIA_ACCEL_REDIRECT", False):
+            # nginx serves the bytes from the `internal` location.
+            resp = HttpResponse(content_type=content_type)
+            resp["X-Accel-Redirect"] = quote(f"/protected-media/{subpath}")
+            resp["Cache-Control"] = "private, max-age=3600"
+            return resp
+
+        # Dev / tests: stream directly.
+        try:
+            f = (settings.MEDIA_ROOT / subpath).open("rb") if hasattr(settings.MEDIA_ROOT, "open") \
+                else open(f"{settings.MEDIA_ROOT}/{subpath}", "rb")
+        except FileNotFoundError:
+            return HttpResponse(status=404)
+        resp = FileResponse(f, content_type=content_type)
+        resp["Cache-Control"] = "private, max-age=3600"
+        return resp

--- a/billing/api/serializers.py
+++ b/billing/api/serializers.py
@@ -203,7 +203,10 @@ class InwardBillListSerializer(serializers.ModelSerializer):
         return url
 
     def get_source_preview_url(self, obj):
-        return self._abs(obj.source_preview.url) if obj.source_preview else None
+        # Signed, expiring URL — /media/ is no longer publicly served.
+        from billing.api.media import sign_media_path
+
+        return sign_media_path(obj.source_preview.name) if obj.source_preview else None
 
 
 class InwardBillSerializer(InwardBillListSerializer):
@@ -219,7 +222,9 @@ class InwardBillSerializer(InwardBillListSerializer):
         ]
 
     def get_source_file_url(self, obj):
-        return self._abs(obj.source_file.url) if obj.source_file else None
+        from billing.api.media import sign_media_path
+
+        return sign_media_path(obj.source_file.name) if obj.source_file else None
 
 
 class InvoiceSummarySerializer(serializers.Serializer):

--- a/billing/api/urls.py
+++ b/billing/api/urls.py
@@ -26,6 +26,7 @@ from .views import (
     ReportView,
     UserManagementView,
 )
+from .media import SignedMediaView
 from .preferences import PreferencesView
 
 router = DefaultRouter()
@@ -69,6 +70,7 @@ urlpatterns = [
     path("profile/", ProfileView.as_view(), name="profile"),
     path("users/", UserManagementView.as_view(), name="user-management"),
     path("preferences/", PreferencesView.as_view(), name="preferences"),
+    path("media/<path:subpath>", SignedMediaView.as_view(), name="signed-media"),
     # JWT Authentication endpoints
     path("token/", ThrottledTokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("token/refresh/", ThrottledTokenRefreshView.as_view(), name="token_refresh"),

--- a/billing/tests/test_healthz.py
+++ b/billing/tests/test_healthz.py
@@ -1,0 +1,23 @@
+"""/healthz — the uptime monitor's view of the app."""
+
+from django.test import Client, TestCase
+from unittest.mock import patch
+
+
+class HealthzTest(TestCase):
+    def test_ok_when_db_answers(self):
+        resp = Client().get("/healthz")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"ok": True, "db": True})
+
+    def test_503_when_db_is_down(self):
+        from django.db import connection
+
+        with patch.object(connection, "cursor", side_effect=OSError("db down")):
+            resp = Client().get("/healthz")
+        self.assertEqual(resp.status_code, 503)
+        self.assertEqual(resp.json(), {"ok": False, "db": False})
+
+    def test_no_auth_required_and_not_swallowed_by_spa_fallback(self):
+        resp = Client().get("/healthz")
+        self.assertEqual(resp["Content-Type"], "application/json")

--- a/billing/tests/test_signed_media.py
+++ b/billing/tests/test_signed_media.py
@@ -1,0 +1,121 @@
+"""Signed media URLs — bill scans stopped being public the day this landed.
+
+The signature is the credential (img/iframe tags can't carry JWT headers),
+so the tests pin exactly what the signature must and must not allow.
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+from django.core.signing import TimestampSigner
+from django.test import override_settings
+from django.urls import reverse
+
+from billing.api.media import sign_media_path
+from billing.tests.test_base import BaseAPITestCase
+
+_MEDIA = tempfile.mkdtemp(prefix="signed_media_test_")
+
+
+@override_settings(MEDIA_ROOT=_MEDIA)
+class SignedMediaTest(BaseAPITestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        (Path(_MEDIA) / "inward_bills").mkdir(parents=True, exist_ok=True)
+        (Path(_MEDIA) / "inward_bills" / "scan.pdf").write_bytes(b"%PDF-1.4 test-bytes")
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(_MEDIA, ignore_errors=True)
+        super().tearDownClass()
+
+    def _get(self, url):
+        # No auth on purpose: the browser fetches these as bare <img>/<iframe>
+        # requests. The signature must be sufficient — and necessary.
+        from rest_framework.test import APIClient
+
+        return APIClient().get(url)
+
+    def test_signed_url_serves_the_file_without_login(self):
+        url = sign_media_path("inward_bills/scan.pdf")
+        resp = self._get(url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(b"".join(resp.streaming_content), b"%PDF-1.4 test-bytes")
+        self.assertIn("application/pdf", resp["Content-Type"])
+        self.assertIn("private", resp["Cache-Control"])
+
+    def test_no_signature_is_forbidden(self):
+        resp = self._get("/api/media/inward_bills/scan.pdf")
+        self.assertEqual(resp.status_code, 403)
+
+    def test_tampered_signature_is_forbidden(self):
+        url = sign_media_path("inward_bills/scan.pdf")
+        resp = self._get(url[:-4] + "XXXX")
+        self.assertEqual(resp.status_code, 403)
+
+    def test_signature_for_one_file_cannot_fetch_another(self):
+        (Path(_MEDIA) / "inward_bills" / "other.pdf").write_bytes(b"other")
+        good = sign_media_path("inward_bills/scan.pdf")
+        token = good.split("?s=")[1]
+        resp = self._get(f"/api/media/inward_bills/other.pdf?s={token}")
+        self.assertEqual(resp.status_code, 403)
+
+    def test_expired_signature_is_forbidden(self):
+        import billing.api.media as media_mod
+        from datetime import timedelta
+
+        from django.core import signing
+
+        old = TimestampSigner(salt="billing.media")
+        # Forge an old timestamp by patching the signer's clock via freezegun-free
+        # trick: sign, then assert unsign with tiny max_age rejects it.
+        token = old.sign("inward_bills/scan.pdf")
+        with self.settings():
+            try:
+                old.unsign(token, max_age=timedelta(seconds=-1))
+                expired = False
+            except signing.SignatureExpired:
+                expired = True
+        self.assertTrue(expired, "negative max_age must reject — expiry mechanism works")
+
+    def test_traversal_paths_are_forbidden_even_if_signed(self):
+        evil = "inward_bills/../../etc/passwd"
+        signer = TimestampSigner(salt="billing.media")
+        from urllib.parse import quote
+
+        url = f"/api/media/{evil}?s={quote(signer.sign(evil))}"
+        resp = self._get(url)
+        self.assertEqual(resp.status_code, 403)
+
+    @override_settings(MEDIA_ACCEL_REDIRECT=True)
+    def test_production_mode_answers_with_accel_redirect(self):
+        url = sign_media_path("inward_bills/scan.pdf")
+        resp = self._get(url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp["X-Accel-Redirect"], "/protected-media/inward_bills/scan.pdf")
+        self.assertFalse(getattr(resp, "streaming", False), "nginx streams, not Django")
+
+    def test_serializer_emits_signed_urls(self):
+        from decimal import Decimal as D
+
+        from django.core.files.uploadedfile import SimpleUploadedFile
+
+        from billing.constants import INVOICE_TYPE_INWARD
+        from billing.models import Invoice
+
+        inv = Invoice.objects.create(
+            workspace_id=1, business=self.business, customer=self.customer,
+            invoice_number="SM-1", invoice_date="2026-08-01",
+            type_of_invoice=INVOICE_TYPE_INWARD, total_amount=D("0"),
+        )
+        inv.source_file.save("bill.pdf", SimpleUploadedFile("bill.pdf", b"%PDF"), save=True)
+        resp = self.client.get(reverse("inward-bill-detail", args=[inv.id]))
+        self.assertEqual(resp.status_code, 200)
+        url = resp.data["source_file_url"]
+        self.assertTrue(url.startswith("/api/media/"), url)
+        self.assertIn("?s=", url)
+        self.assertNotIn("/media/", url.split("?")[0].replace("/api/media/", ""), "no public /media/ leak")
+        # And the minted URL actually works, unauthenticated:
+        self.assertEqual(self._get(url).status_code, 200)

--- a/deploy/backup/backup.sh
+++ b/deploy/backup/backup.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# Nightly backup loop. Runs inside postgres:16-alpine with the app's .env:
+# DB_HOST/DB_PORT/DB_NAME/DB_USER/DB_PASSWORD (Neon needs PGSSLMODE=require,
+# set by compose). Writes to /backups (host ./backups), keeps 30 days.
+#
+# Restore (drill this once — an untested backup is a hope, not a backup):
+#   docker compose exec backup sh
+#   pg_restore --list /backups/db-<stamp>.dump | head          # sanity
+#   createdb -h "$DB_HOST" -U "$DB_USER" restore_drill
+#   pg_restore -h "$DB_HOST" -U "$DB_USER" -d restore_drill --no-owner \
+#       /backups/db-<stamp>.dump
+#   psql -h "$DB_HOST" -U "$DB_USER" -d restore_drill \
+#       -c 'SELECT COUNT(*) FROM billing_invoice;'
+#   dropdb  -h "$DB_HOST" -U "$DB_USER" restore_drill
+# Media: tar -tzf /backups/media-<stamp>.tar.gz | head
+
+set -u
+mkdir -p /backups
+
+while true; do
+    ts=$(date +%Y%m%d-%H%M)
+    echo "[backup] $ts starting"
+
+    export PGPASSWORD="$DB_PASSWORD"
+    if pg_dump -h "$DB_HOST" -p "${DB_PORT:-5432}" -U "$DB_USER" -d "$DB_NAME" \
+        --no-owner --format=custom -f "/backups/db-$ts.dump"; then
+        # A dump that pg_restore cannot even list is not a backup.
+        entries=$(pg_restore --list "/backups/db-$ts.dump" | wc -l)
+        echo "[backup] db-$ts.dump ok ($entries archive entries)"
+    else
+        echo "[backup] ERROR: pg_dump failed" >&2
+        rm -f "/backups/db-$ts.dump"
+    fi
+
+    if tar -czf "/backups/media-$ts.tar.gz" -C /media .; then
+        echo "[backup] media-$ts.tar.gz ok ($(du -h "/backups/media-$ts.tar.gz" | cut -f1))"
+    else
+        echo "[backup] ERROR: media tar failed" >&2
+    fi
+
+    find /backups -type f -mtime +30 -delete
+    echo "[backup] done; sleeping 24h"
+    sleep 86400
+done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,4 +66,26 @@ services:
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+    # Set WATCHTOWER_NOTIFICATION_URL in .env (shoutrrr format, e.g.
+    # telegram://<bot-token>@telegram?chats=<chat-id>) and every deploy —
+    # or failed pull — announces itself. Empty means no notifications.
+    environment:
+      - WATCHTOWER_NOTIFICATION_URL=${WATCHTOWER_NOTIFICATION_URL:-}
     command: --label-enable --cleanup --interval 60
+
+  # Nightly backups: pg_dump of the (external) Postgres + a tar of the media
+  # volume, kept 30 days under ./backups on the host. Deliberately NOT
+  # watchtower-labeled — a backup container should never restart mid-dump.
+  # Restore drill: see DEPLOYMENT.md "Backups".
+  backup:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    env_file:
+      - ./.env
+    environment:
+      - PGSSLMODE=require
+    volumes:
+      - gst_media_volume:/media:ro
+      - ./backups:/backups
+      - ./deploy/backup:/opt/backup:ro
+    entrypoint: ["sh", "/opt/backup/backup.sh"]

--- a/gst_billing/production_settings.py
+++ b/gst_billing/production_settings.py
@@ -135,6 +135,10 @@ STATICFILES_DIRS = [
 # bare local run) change nothing. Until this, a production exception was
 # invisible unless someone happened to tail the container logs — the E-way
 # button crashed for four months without anyone knowing.
+# Signed media URLs hand the actual file streaming to nginx via
+# X-Accel-Redirect (see billing/api/media.py + nginx protected-media block).
+MEDIA_ACCEL_REDIRECT = True
+
 SENTRY_DSN = os.environ.get("SENTRY_DSN", "")
 if SENTRY_DSN:
     import sentry_sdk

--- a/gst_billing/urls.py
+++ b/gst_billing/urls.py
@@ -30,6 +30,24 @@ urlpatterns = [
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
+# Liveness for uptime monitors and Watchtower sanity: 200 when the DB
+# answers, 503 when it doesn't. Registered before the SPA fallback so the
+# catch-all never swallows it. No auth — it leaks nothing but "up".
+def healthz(request):
+    from django.db import connection
+    from django.http import JsonResponse
+
+    try:
+        with connection.cursor() as c:
+            c.execute("SELECT 1")
+        return JsonResponse({"ok": True, "db": True})
+    except Exception:
+        return JsonResponse({"ok": False, "db": False}, status=503)
+
+
+urlpatterns += [path("healthz", healthz)]
+
+
 # SPA fallback — nginx serves the real app in production; this answers direct
 # Django hits (dev runserver, probes) now that the V1 webpack shell is deleted.
 # The negative lookahead keeps unknown /api/ paths as JSON 404s, not HTML 200s.

--- a/nginx/conf.d/app.conf
+++ b/nginx/conf.d/app.conf
@@ -75,6 +75,13 @@ server {
         add_header Permissions-Policy "camera=(self), microphone=(), geolocation=(), payment=()" always;
     }
 
+    # Liveness probe — proxied to Django, quiet in the logs.
+    location = /healthz {
+        proxy_pass http://web:8000;
+        proxy_set_header Host $host;
+        access_log off;
+    }
+
     # Django API endpoints
     location /api/ {
         proxy_pass http://web:8000;

--- a/nginx/conf.d/app.conf
+++ b/nginx/conf.d/app.conf
@@ -10,6 +10,20 @@ map $http_x_forwarded_proto $forwarded_proto {
 # Compression — the main SPA bundle measured 464 KB served raw (no
 # content-encoding, verified live 19 Aug 2026); it gzips to ~150 KB. conf.d
 # files are included in the http context, so this covers every location below.
+# Hide the exact nginx version from response headers and error pages.
+server_tokens off;
+
+# Brute-force guard for the session-auth login surfaces. Keyed so that ONLY
+# POSTs count (an empty key is never limited): admins can browse freely, but
+# password attempts are capped per IP. The API's own /api/token/ endpoint is
+# already throttled application-side (10/min) since #79.
+map $request_method $auth_post_key {
+    default "";
+    POST    $binary_remote_addr;
+}
+limit_req_zone $auth_post_key zone=authpost:1m rate=5r/m;
+limit_req_status 429;
+
 gzip on;
 gzip_vary on;
 gzip_comp_level 6;
@@ -20,6 +34,13 @@ gzip_types text/css application/javascript application/json image/svg+xml text/p
 server {
     listen 80;
     server_name billing.cheq.dpdns.org;
+
+    # Base security headers. NOTE nginx's add_header inheritance: a location
+    # that sets ANY add_header of its own loses these — such locations
+    # (/static/, /assets/, /, /protected-media/) repeat them explicitly.
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(self), microphone=(), geolocation=(), payment=()" always;
 
     # Redirect HTTP to HTTPS
     # Uncomment these lines after you set up SSL
@@ -32,12 +53,26 @@ server {
         alias /var/www/static/;
         expires 30d;
         add_header Cache-Control "public, max-age=2592000";
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(self), microphone=(), geolocation=(), payment=()" always;
     }
 
+    # Bill scans are private books data. The public /media/ mount is gone:
+    # files are reachable only through signed URLs (/api/media/<path>?s=…,
+    # billing/api/media.py) whose view answers with X-Accel-Redirect into the
+    # `internal` location below — auth in Django, byte-streaming in nginx.
     location /media/ {
+        return 404;
+    }
+
+    location /protected-media/ {
+        internal;
         alias /var/www/media/;
-        expires 30d;
-        add_header Cache-Control "public, max-age=2592000";
+        add_header Cache-Control "private, max-age=3600";
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(self), microphone=(), geolocation=(), payment=()" always;
     }
 
     # Django API endpoints
@@ -49,8 +84,9 @@ server {
         proxy_set_header X-Forwarded-Proto $forwarded_proto;
     }
 
-    # Django Admin endpoints
+    # Django Admin endpoints — login POSTs rate-limited (see authpost zone)
     location /admin/ {
+        limit_req zone=authpost burst=10 nodelay;
         proxy_pass http://web:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -58,8 +94,10 @@ server {
         proxy_set_header X-Forwarded-Proto $forwarded_proto;
     }
 
-    # Django Explorer plugin
+    # Django Explorer plugin — same POST rate limit; it renders the login
+    # form on every unauthenticated hit.
     location /explorer/ {
+        limit_req zone=authpost burst=10 nodelay;
         proxy_pass http://web:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -74,6 +112,16 @@ server {
         root /usr/share/nginx/html;
         expires 1y;
         add_header Cache-Control "public, immutable";
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(self), microphone=(), geolocation=(), payment=()" always;
+        # CSP applies to the SPA only — Django admin/explorer use inline
+        # scripts and get no CSP from us. script-src 'self' is the crown
+        # jewel: with JWTs in localStorage, it turns most XSS from silent
+        # token theft into a console error. Verified against dist/: one
+        # external module script, no inline scripts, no external origins.
+        # blob: in frame-src/img-src covers the PDF preview + QR flows.
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; frame-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'" always;
     }
 
     # React Frontend (index.html + the SPA fallback for client routes)
@@ -81,6 +129,16 @@ server {
         root /usr/share/nginx/html;
         try_files $uri $uri/ /index.html;
         add_header Cache-Control "no-cache";
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(self), microphone=(), geolocation=(), payment=()" always;
+        # CSP applies to the SPA only — Django admin/explorer use inline
+        # scripts and get no CSP from us. script-src 'self' is the crown
+        # jewel: with JWTs in localStorage, it turns most XSS from silent
+        # token theft into a console error. Verified against dist/: one
+        # external module script, no inline scripts, no external origins.
+        # blob: in frame-src/img-src covers the PDF preview + QR flows.
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; frame-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'" always;
     }
 }
 


### PR DESCRIPTION
Two waves in one PR (keeping the PR count down): locks the doors on media/auth, then adds the safety net — backups, health checks, deploy alerts.

## 1. Security: signed media URLs
Uploaded bill scans were publicly fetchable at `/media/...` with no auth. Now:
- **`/api/media/<path>?s=<sig>`** — HMAC-signed, 6-hour expiring URLs (`TimestampSigner`), minted only inside authenticated API responses. Signature must match the exact path; traversal shapes rejected.
- **Production**: Django validates the signature and answers `X-Accel-Redirect`; nginx streams the bytes from an `internal` location. Django never proxies files.
- **nginx**: public `/media/` now 404s; `/protected-media/` is `internal`-only.

## 2. Security: login rate limits + headers
- `map`-based **POST-only** `limit_req` (5/min + burst 10) on `/admin/` and `/explorer/` — GETs unaffected, so the admin UI stays snappy.
- **CSP** on the SPA locations only (`script-src 'self'`; Django admin excluded — it needs inline scripts), `server_tokens off`, nosniff/referrer/permissions headers re-asserted in every location that sets its own headers (nginx `add_header` inheritance trap).
- New CI job: `nginx -t` validates the shipped conf in the real nginx image on every PR.

## 3. Ops: nightly backups
- `backup` sidecar (postgres:16-alpine, **not** watchtower-labeled): daily `pg_dump --format=custom` (verified with `pg_restore --list`) + media tar → `./backups`, 30-day retention.
- `DEPLOYMENT.md`: setup, off-site note, and a **restore drill** to run once now.

## 4. Ops: /healthz + deploy notifications
- `GET /healthz` — 200 when the DB answers, 503 when not; no auth; registered ahead of the SPA fallback; nginx proxies it with `access_log off`. Point UptimeRobot at it.
- `WATCHTOWER_NOTIFICATION_URL` (shoutrrr) passthrough — set it in `.env` and every deploy announces itself.

## Tests
196 backend tests pass (8 new signed-media + 3 new healthz). Frontend untouched.

## After merge (server, one time)
```bash
mkdir -p backups && docker compose pull && docker compose up -d
```
…then run the restore drill from DEPLOYMENT.md and optionally set `WATCHTOWER_NOTIFICATION_URL` in `.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
