### PR TITLE
GSTR-1 portal JSON export — GSTN offline-tool import file

### DIFF
--- a/billing/api/views.py
+++ b/billing/api/views.py
@@ -2049,6 +2049,219 @@ class InvoiceViewSet(AuditLogMixin, viewsets.ModelViewSet):
             "gstr2b": {"inward_invoices": inward_list},
         })
 
+    @action(detail=False, methods=["get"], url_path="gstr1-portal-json")
+    def gstr1_portal_json(self, request):
+        """GSTR-1 as the GST portal offline tool's import JSON.
+
+        One business, one month — that's the granularity the portal files at,
+        so unlike gstr_export this endpoint refuses to run without both.
+        Returns {"file": <upload as-is>, "meta": {counts, skipped, warnings}}:
+        only `file` goes to the portal; extra keys inside it break the import,
+        which is why the diagnostics live outside it.
+
+        Differences from the gstr_export shape that the portal cares about:
+        - gstin/fp header present, values quantized to exactly 2 decimals
+          (float artifacts like 0.30000000000000004 fail schema validation)
+        - b2cs carries the mandatory sply_ty, and inter-state B2C sales at or
+          under the B2CL threshold are filed here as INTER rows — previously
+          they fell through both sections and were silently missing
+        - b2cl groups invoices under one entry per place of supply
+        - per-invoice items are aggregated per rate slab with serial nums
+        - HSN summary (table 12, mandatory since 2021) is included
+        """
+        try:
+            business = Business.objects.get(id=int(request.query_params.get("business_id") or 0))
+        except (ValueError, Business.DoesNotExist):
+            return Response({"error": "A valid business_id is required."}, status=400)
+        try:
+            month = int(request.query_params.get("month") or 0)
+            year = int(request.query_params.get("year") or 0)
+            assert 1 <= month <= 12 and 2017 <= year <= 2099
+        except (ValueError, AssertionError):
+            return Response({"error": "month (1-12) and year are required."}, status=400)
+
+        gstin = (business.gst_number or "").strip().upper()
+        if len(gstin) != 15:
+            return Response(
+                {"error": f"Business '{business.name}' has no 15-character GSTIN — "
+                          "set it before generating a portal file."},
+                status=400,
+            )
+
+        TWO = Decimal("0.01")
+
+        def r2(x):
+            return float(Decimal(x or 0).quantize(TWO))
+
+        def rate_pct(li):
+            r = li.gst_tax_rate or Decimal(0)
+            return float(r * 100 if r <= 1 else r)
+
+        UQC = {"gms": "GMS", "gm": "GMS", "g": "GMS", "kg": "KGS", "kgs": "KGS",
+               "pcs": "PCS", "pc": "PCS", "nos": "NOS", "carat": "CTM", "ct": "CTM"}
+
+        invoices = (
+            Invoice.objects.filter(
+                business=business, type_of_invoice="outward",
+                invoice_date__year=year, invoice_date__month=month,
+            )
+            .select_related("customer")
+            .prefetch_related("lineitem_set")
+            .order_by("invoice_date", "id")
+        )
+
+        skipped, warnings = [], []
+        b2b_data, b2cl_data, b2cs_agg, hsn_agg = {}, {}, {}, {}
+        biz_pos = state_code(business)
+        counts = {"b2b": 0, "b2cl": 0, "b2cs": 0}
+
+        def slabs(items):
+            """Aggregate an invoice's lines into per-rate slabs (portal itms)."""
+            agg = {}
+            for li in items:
+                rt = rate_pct(li)
+                s = agg.setdefault(rt, {"txval": Decimal(0), "camt": Decimal(0),
+                                        "samt": Decimal(0), "iamt": Decimal(0)})
+                s["txval"] += (li.quantity or 0) * (li.rate or 0)
+                s["camt"] += li.cgst or 0
+                s["samt"] += li.sgst or 0
+                s["iamt"] += li.igst or 0
+            return agg
+
+        for inv in invoices:
+            items = list(inv.lineitem_set.all())
+            label = f"{inv.invoice_number or '(no number)'} / {inv.invoice_date}"
+            if not inv.invoice_number or not inv.invoice_date:
+                skipped.append(f"{label}: missing invoice number or date")
+                continue
+            if not items:
+                skipped.append(f"{label}: no line items")
+                continue
+
+            agg = slabs(items)
+            idt = inv.invoice_date.strftime("%d-%m-%Y")
+            val = r2(inv.total_amount)
+            cust_gstin = (inv.customer.gst_number or "").strip().upper()
+
+            if len(cust_gstin) == 15:
+                itms = [
+                    {"num": i + 1, "itm_det": {
+                        "txval": r2(s["txval"]), "rt": rt,
+                        "camt": r2(s["camt"]), "samt": r2(s["samt"]),
+                        "iamt": r2(s["iamt"]), "csamt": 0,
+                    }}
+                    for i, (rt, s) in enumerate(sorted(agg.items()))
+                ]
+                b2b_data.setdefault(cust_gstin, {"ctin": cust_gstin, "inv": []})["inv"].append({
+                    "inum": inv.invoice_number, "idt": idt, "val": val,
+                    "pos": cust_gstin[:2], "rchrg": "N", "inv_typ": "R", "itms": itms,
+                })
+                counts["b2b"] += 1
+                continue
+
+            inter = is_interstate(business, inv.customer)
+            cust_pos = state_code(inv.customer)
+
+            if inter and not cust_pos:
+                warnings.append(f"{label}: inter-state but customer state unknown — filed as intra-state")
+                inter = False
+
+            if inter and float(inv.total_amount) > B2CL_THRESHOLD:
+                itms = [
+                    {"num": i + 1, "itm_det": {
+                        "txval": r2(s["txval"]), "rt": rt,
+                        "iamt": r2(s["iamt"]), "csamt": 0,
+                    }}
+                    for i, (rt, s) in enumerate(sorted(agg.items()))
+                ]
+                b2cl_data.setdefault(cust_pos, {"pos": cust_pos, "inv": []})["inv"].append({
+                    "inum": inv.invoice_number, "idt": idt, "val": val, "itms": itms,
+                })
+                counts["b2cl"] += 1
+                continue
+
+            # Consolidated B2C: intra-state at any value, inter-state <= threshold.
+            pos = cust_pos if inter else (biz_pos or gstin[:2])
+            sply = "INTER" if inter else "INTRA"
+            for rt, s in agg.items():
+                b = b2cs_agg.setdefault((sply, pos, rt), {
+                    "sply_ty": sply, "pos": pos, "typ": "OE", "rt": rt,
+                    "txval": Decimal(0), "camt": Decimal(0),
+                    "samt": Decimal(0), "iamt": Decimal(0),
+                })
+                b["txval"] += s["txval"]
+                b["camt"] += s["camt"]
+                b["samt"] += s["samt"]
+                b["iamt"] += s["iamt"]
+                if sply == "INTRA" and s["iamt"]:
+                    warnings.append(f"{label}: intra-state supply carries IGST — run fix_tax_heads")
+                if sply == "INTER" and (s["camt"] or s["samt"]):
+                    warnings.append(f"{label}: inter-state supply carries CGST/SGST — run fix_tax_heads")
+            counts["b2cs"] += 1
+
+        # HSN summary (table 12) over everything that made it into the file.
+        for inv in invoices:
+            if not inv.invoice_number or not inv.invoice_date:
+                continue
+            for li in inv.lineitem_set.all():
+                hsn = (li.hsn_code or "").strip()
+                uqc = UQC.get((li.unit or "").strip().lower(), "OTH")
+                rt = rate_pct(li)
+                h = hsn_agg.setdefault((hsn, uqc, rt), {
+                    "hsn_sc": hsn, "desc": (li.product_name or "")[:30], "uqc": uqc,
+                    "rt": rt, "qty": Decimal(0), "txval": Decimal(0),
+                    "camt": Decimal(0), "samt": Decimal(0), "iamt": Decimal(0),
+                })
+                h["qty"] += li.quantity or 0
+                h["txval"] += (li.quantity or 0) * (li.rate or 0)
+                h["camt"] += li.cgst or 0
+                h["samt"] += li.sgst or 0
+                h["iamt"] += li.igst or 0
+                if not hsn:
+                    warnings.append(f"{inv.invoice_number}: line '{li.product_name}' has no HSN")
+
+        fp = f"{month:02d}{year}"
+        file_obj = {"gstin": gstin, "fp": fp, "version": "GST3.2.1", "hash": "hash"}
+        if b2b_data:
+            file_obj["b2b"] = list(b2b_data.values())
+        if b2cl_data:
+            file_obj["b2cl"] = list(b2cl_data.values())
+        if b2cs_agg:
+            file_obj["b2cs"] = [
+                {"sply_ty": b["sply_ty"], "pos": b["pos"], "typ": b["typ"], "rt": b["rt"],
+                 "txval": r2(b["txval"]),
+                 **({"iamt": r2(b["iamt"])} if b["sply_ty"] == "INTER"
+                    else {"camt": r2(b["camt"]), "samt": r2(b["samt"])}),
+                 "csamt": 0}
+                for b in b2cs_agg.values()
+            ]
+        if hsn_agg:
+            file_obj["hsn"] = {"data": [
+                {"num": i + 1, "hsn_sc": h["hsn_sc"], "desc": h["desc"], "uqc": h["uqc"],
+                 "qty": r2(h["qty"]), "rt": h["rt"], "txval": r2(h["txval"]),
+                 "camt": r2(h["camt"]), "samt": r2(h["samt"]),
+                 "iamt": r2(h["iamt"]), "csamt": 0}
+                for i, h in enumerate(hsn_agg.values())
+            ]}
+
+        total_txval = sum(
+            r2(b["txval"]) for b in b2cs_agg.values()
+        ) + sum(
+            i["itm_det"]["txval"] for g in b2b_data.values() for v in g["inv"] for i in v["itms"]
+        ) + sum(
+            i["itm_det"]["txval"] for g in b2cl_data.values() for v in g["inv"] for i in v["itms"]
+        )
+
+        return Response({
+            "file": file_obj,
+            "meta": {
+                "business": business.name, "gstin": gstin, "fp": fp,
+                "invoice_counts": counts,
+                "taxable_total": round(total_txval, 2),
+                "skipped": skipped, "warnings": warnings,
+            },
+        })
+
     @action(detail=False, methods=["get"])
     def next_invoice_number(self, request):
         """Get the next invoice number for a business.

--- a/billing/tests/test_gstr1_portal.py
+++ b/billing/tests/test_gstr1_portal.py
@@ -1,0 +1,179 @@
+"""GSTR-1 portal JSON — the file must import into the GSTN offline tool as-is.
+
+Fixture set covers every classification the portal distinguishes, including
+the case the old gstr_export dropped entirely: inter-state B2C at or under
+the B2CL threshold, which must land in b2cs as an INTER row.
+"""
+
+import json
+from decimal import Decimal as D
+
+from django.urls import reverse
+
+from billing.models import Customer, Invoice, LineItem
+from billing.tests.test_base import BaseAPITestCase
+
+
+class Gstr1PortalJsonTest(BaseAPITestCase):
+    maxDiff = None
+
+    def setUp(self):
+        super().setUp()
+        # Business GSTIN 22AAAAA0000A1Z5 → state 22. The base fixture pairs it
+        # with state_name MAHARASHTRA; align the name so the B2C direction
+        # fallback (state-name comparison) agrees with the GSTIN.
+        self.business.state_name = "CHHATTISGARH"
+        self.business.save(update_fields=["state_name"])
+        self.reg_intra = Customer.objects.create(
+            workspace_id=1, name="Registered Intra",
+            gst_number="22CCCCC0000C1Z5", state_name="CHHATTISGARH")
+        self.reg_inter = Customer.objects.create(
+            workspace_id=1, name="Registered Inter",
+            gst_number="08DDDDD0000D1Z5", state_name="RAJASTHAN")
+        self.b2c_intra = Customer.objects.create(
+            workspace_id=1, name="Walk-in Local", state_name="CHHATTISGARH")
+        self.b2c_inter_small = Customer.objects.create(
+            workspace_id=1, name="Small Outstation", state_name="RAJASTHAN")
+        self.b2c_inter_large = Customer.objects.create(
+            workspace_id=1, name="Big Outstation", state_name="RAJASTHAN")
+        for c in (self.reg_intra, self.reg_inter, self.b2c_intra,
+                  self.b2c_inter_small, self.b2c_inter_large):
+            c.businesses.add(self.business)
+
+    def _invoice(self, customer, number, taxable, cgst=0, sgst=0, igst=0,
+                 date="2026-07-15", hsn="711311", unit="gms"):
+        total = D(taxable) + D(cgst) + D(sgst) + D(igst)
+        inv = Invoice.objects.create(
+            workspace_id=1, business=self.business, customer=customer,
+            invoice_number=number, invoice_date=date,
+            type_of_invoice="outward", total_amount=total)
+        LineItem.objects.create(
+            workspace_id=1, customer=customer, invoice=inv,
+            product_name="Silver Item", hsn_code=hsn,
+            gst_tax_rate=D("0.03"), quantity=D(taxable), rate=D("1"),
+            cgst=D(cgst), sgst=D(sgst), igst=D(igst), unit=unit,
+            amount=total)
+        return inv
+
+    def _get(self, **params):
+        base = {"business_id": self.business.id, "month": 7, "year": 2026}
+        base.update(params)
+        return self.client.get(reverse("invoice-gstr1-portal-json"), base)
+
+    def _standard_fixture(self):
+        self._invoice(self.reg_intra, "R-1", "10000", cgst="150", sgst="150")
+        self._invoice(self.reg_inter, "R-2", "20000", igst="600")
+        self._invoice(self.b2c_intra, "C-1", "5000", cgst="75", sgst="75")
+        self._invoice(self.b2c_inter_small, "C-2", "40000", igst="1200")
+        self._invoice(self.b2c_inter_large, "C-3", "300000", igst="9000")
+
+    def test_header_and_sections(self):
+        self._standard_fixture()
+        resp = self._get()
+        self.assertEqual(resp.status_code, 200, resp.data)
+        f = resp.data["file"]
+        self.assertEqual(f["gstin"], "22AAAAA0000A1Z5")
+        self.assertEqual(f["fp"], "072026")
+        self.assertEqual(sorted(f["b2b"][0]["ctin"] for _ in [0]), [f["b2b"][0]["ctin"]])
+        self.assertEqual({g["ctin"] for g in f["b2b"]},
+                         {"22CCCCC0000C1Z5", "08DDDDD0000D1Z5"})
+        # File must be pure JSON (portal parses it byte-for-byte).
+        json.dumps(f)
+
+    def test_b2b_rates_aggregated_and_pos_from_ctin(self):
+        self._standard_fixture()
+        f = self._get().data["file"]
+        inter = next(g for g in f["b2b"] if g["ctin"] == "08DDDDD0000D1Z5")
+        inv = inter["inv"][0]
+        self.assertEqual(inv["pos"], "08")
+        self.assertEqual(inv["rchrg"], "N")
+        self.assertEqual(inv["inv_typ"], "R")
+        self.assertEqual(inv["itms"], [{"num": 1, "itm_det": {
+            "txval": 20000.0, "rt": 3.0, "camt": 0.0, "samt": 0.0,
+            "iamt": 600.0, "csamt": 0}}])
+
+    def test_interstate_b2c_under_threshold_lands_in_b2cs_as_inter(self):
+        """The bug fix: these sales used to vanish from the return."""
+        self._standard_fixture()
+        f = self._get().data["file"]
+        inter_rows = [b for b in f["b2cs"] if b["sply_ty"] == "INTER"]
+        self.assertEqual(len(inter_rows), 1)
+        row = inter_rows[0]
+        self.assertEqual(row["pos"], "08")
+        self.assertEqual(row["txval"], 40000.0)
+        self.assertEqual(row["iamt"], 1200.0)
+        self.assertNotIn("camt", row)
+
+    def test_intra_b2c_lands_in_b2cs_as_intra(self):
+        self._standard_fixture()
+        f = self._get().data["file"]
+        intra = next(b for b in f["b2cs"] if b["sply_ty"] == "INTRA")
+        self.assertEqual(intra["pos"], "22")
+        self.assertEqual(intra["txval"], 5000.0)
+        self.assertEqual(intra["camt"], 75.0)
+        self.assertEqual(intra["samt"], 75.0)
+        self.assertNotIn("iamt", intra)
+
+    def test_large_interstate_b2c_lands_in_b2cl_grouped_by_pos(self):
+        self._standard_fixture()
+        f = self._get().data["file"]
+        self.assertEqual(len(f["b2cl"]), 1)
+        grp = f["b2cl"][0]
+        self.assertEqual(grp["pos"], "08")
+        self.assertEqual(grp["inv"][0]["val"], 309000.0)
+        self.assertEqual(grp["inv"][0]["itms"][0]["itm_det"]["iamt"], 9000.0)
+        self.assertNotIn("camt", grp["inv"][0]["itms"][0]["itm_det"])
+
+    def test_taxable_total_reconciles_across_sections(self):
+        self._standard_fixture()
+        data = self._get().data
+        f = data["file"]
+        sections = sum(b["txval"] for b in f["b2cs"])
+        sections += sum(i["itm_det"]["txval"]
+                        for g in f["b2b"] for v in g["inv"] for i in v["itms"])
+        sections += sum(i["itm_det"]["txval"]
+                        for g in f["b2cl"] for v in g["inv"] for i in v["itms"])
+        self.assertEqual(sections, 375000.0)
+        self.assertEqual(data["meta"]["taxable_total"], 375000.0)
+        hsn_total = sum(h["txval"] for h in f["hsn"]["data"])
+        self.assertEqual(hsn_total, 375000.0)
+
+    def test_hsn_summary_units_and_rates(self):
+        self._standard_fixture()
+        f = self._get().data["file"]
+        rows = f["hsn"]["data"]
+        self.assertEqual(len(rows), 1)  # same hsn+uqc+rate everywhere
+        self.assertEqual(rows[0]["hsn_sc"], "711311")
+        self.assertEqual(rows[0]["uqc"], "GMS")
+        self.assertEqual(rows[0]["qty"], 375000.0)
+
+    def test_unfilable_invoices_are_skipped_and_reported(self):
+        self._standard_fixture()
+        no_number = self._invoice(self.b2c_intra, "TMP", "999", cgst="15", sgst="15")
+        no_number.invoice_number = ""
+        no_number.save(update_fields=["invoice_number"])
+        data = self._get().data
+        self.assertEqual(len(data["meta"]["skipped"]), 1)
+        self.assertIn("missing invoice number", data["meta"]["skipped"][0])
+        intra = next(b for b in data["file"]["b2cs"] if b["sply_ty"] == "INTRA")
+        self.assertEqual(intra["txval"], 5000.0, "skipped invoice must not leak into totals")
+
+    def test_month_scoping_excludes_other_months(self):
+        self._standard_fixture()
+        self._invoice(self.b2c_intra, "AUG-1", "7777", cgst="116.66", sgst="116.66",
+                      date="2026-08-02")
+        f = self._get().data["file"]
+        intra = next(b for b in f["b2cs"] if b["sply_ty"] == "INTRA")
+        self.assertEqual(intra["txval"], 5000.0)
+
+    def test_business_without_gstin_is_400(self):
+        self.business.gst_number = ""
+        self.business.save(update_fields=["gst_number"])
+        resp = self._get()
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("GSTIN", resp.data["error"])
+
+    def test_missing_month_is_400(self):
+        resp = self.client.get(reverse("invoice-gstr1-portal-json"),
+                               {"business_id": self.business.id})
+        self.assertEqual(resp.status_code, 400)

--- a/sweet-rebuild-suite-main/src/pages/GSTSummary.tsx
+++ b/sweet-rebuild-suite-main/src/pages/GSTSummary.tsx
@@ -307,6 +307,39 @@ export default function GSTSummary() {
     toast({ title: "Downloaded", description: `${section.toUpperCase()} JSON exported` });
   };
 
+  // Portal JSON files one (business, month) — exactly what the GSTN offline
+  // tool imports. Anything looser (All months, custom range, All businesses)
+  // can't produce a valid return period, so the button gates on both.
+  const portalReady = bizFilter !== "all" && selectedMonth !== "All" && !useCustomRange;
+  const [portalBusy, setPortalBusy] = useState(false);
+  const handleDownloadPortalJSON = async () => {
+    if (!portalReady || portalBusy) return;
+    const y = monthIdx < 9 ? fyStart : fyStart + 1;
+    const m = monthIdx < 9 ? monthIdx + 4 : monthIdx - 8;
+    setPortalBusy(true);
+    try {
+      const res = await api.get<any>(`invoices/gstr1-portal-json/?business_id=${bizFilter}&month=${m}&year=${y}`);
+      const { file, meta } = res.data;
+      const blob = new Blob([JSON.stringify(file)], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url; a.download = `GSTR1_${meta.gstin}_${meta.fp}.json`; a.click();
+      URL.revokeObjectURL(url);
+      const c = meta.invoice_counts;
+      const issues = (meta.skipped?.length || 0) + (meta.warnings?.length || 0);
+      toast({
+        title: "Portal JSON ready",
+        description: `${c.b2b} B2B, ${c.b2cl} B2CL, ${c.b2cs} B2C invoices — upload on the portal via Returns → GSTR-1 → Prepare Offline${issues ? `. ${issues} item(s) need attention — check the data-quality banner.` : ""}`,
+      });
+      if (meta.skipped?.length) logger.warn("GSTR-1 portal export skipped invoices", meta.skipped);
+      if (meta.warnings?.length) logger.warn("GSTR-1 portal export warnings", meta.warnings);
+    } catch (e: any) {
+      toast({ title: "Export failed", description: e?.response?.data?.error || "Could not build the portal file", variant: "destructive" });
+    } finally {
+      setPortalBusy(false);
+    }
+  };
+
   const TABS: { key: TabKey; label: string }[] = [
     { key: "summary", label: "Summary" },
     { key: "gstr1", label: "GSTR-1 (Outward)" },
@@ -827,7 +860,17 @@ export default function GSTSummary() {
               <div className="space-y-4">
                 <div className="flex items-center justify-between">
                   <h3 className="text-[14px] font-semibold">GSTR-1 — Outward Supplies</h3>
-                  <button onClick={() => handleDownloadJSON("gstr1")} className="premium-btn-primary text-[12px] h-9"><FileJson className="w-3.5 h-3.5" /> Download JSON</button>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={handleDownloadPortalJSON}
+                      disabled={!portalReady || portalBusy}
+                      title={portalReady ? "GSTN offline-tool import file for the selected business and month" : "Select one business and one month (not All / custom range) to build a portal file"}
+                      className="premium-btn-ghost text-[12px] h-9 disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {portalBusy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <FileJson className="w-3.5 h-3.5" />} Portal JSON
+                    </button>
+                    <button onClick={() => handleDownloadJSON("gstr1")} className="premium-btn-primary text-[12px] h-9"><FileJson className="w-3.5 h-3.5" /> Download JSON</button>
+                  </div>
                 </div>
                 <div className="space-y-2">
                   <h4 className="text-[12px] font-semibold text-muted-foreground uppercase tracking-wider">B2B — Registered Dealers ({pluralize(exGstr1.b2b?.length || 0, "party", "parties")})</h4>


### PR DESCRIPTION
## What
`GET /api/invoices/gstr1-portal-json/?business_id&month&year` returns `{file, meta}` where **`file` is the exact JSON the GST portal's offline tool imports** — `gstin`/`fp` header, `b2b` / `b2cl` / `b2cs` / `hsn` sections, every value quantized to 2 decimals, `pos` zero-padded, `sply_ty` present on b2cs, per-invoice items aggregated into rate slabs. Diagnostics (skipped invoices, tax-head warnings, section counts) ride in `meta`, outside the portal file, because extra keys inside it break the import.

**Filing-gap fix along the way**: `gstr_export` skips inter-state B2C from `b2cs` and sub-₹2.5L invoices from `b2cl` — so an inter-state B2C sale ≤ ₹2.5L appeared in **neither** section and silently vanished from the return. They now file correctly as `b2cs` INTER rows.

## Frontend
"Portal JSON" button on the GSTR-1 filing tab. Enabled only when one business **and** one specific month are selected (a portal file has exactly that granularity); downloads `GSTR1_<gstin>_<fp>.json` and toasts section counts plus a heads-up when invoices were skipped or tax heads look wrong.

## Tests
11 new tests (`test_gstr1_portal.py`): section routing for all five customer classes, rate aggregation, pos derivation, the ≤2.5L inter-state fix, totals reconciling across b2b+b2cl+b2cs and the HSN table, month scoping, skip reporting, and 400s for missing GSTIN/month. Full backend suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
