### PR TITLE
Fix main typecheck (payment-mode types) + recover stranded UI sweep

### DIFF
--- a/sweet-rebuild-suite-main/src/components/QuickCustomerModal.tsx
+++ b/sweet-rebuild-suite-main/src/components/QuickCustomerModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { useGstinLookup } from "@/hooks/useGstinLookup";
 import { validateGstin } from "@/utils/gstin";
 import GstinStatus from "@/components/GstinStatus";
@@ -107,7 +108,9 @@ export default function QuickCustomerModal({ open, onClose, onCreated }: QuickCu
     setSubmitting(false);
   };
 
-  return (
+  // Portal to <body>: a transformed ancestor (page transition mid-flight)
+  // otherwise becomes the containing block for this fixed overlay.
+  return createPortal(
     <AnimatePresence>
       {open && (
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
@@ -177,7 +180,8 @@ export default function QuickCustomerModal({ open, onClose, onCreated }: QuickCu
           </motion.div>
         </motion.div>
       )}
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body
   );
 }
 

--- a/sweet-rebuild-suite-main/src/components/QuickProductModal.tsx
+++ b/sweet-rebuild-suite-main/src/components/QuickProductModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { X, Package, Save, Hash, Percent, FileText } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
@@ -50,7 +51,9 @@ export default function QuickProductModal({ open, onClose, onCreated }: QuickPro
     setErrors({});
   };
 
-  return (
+  // Portal to <body>: a transformed ancestor (page transition mid-flight)
+  // otherwise becomes the containing block for this fixed overlay.
+  return createPortal(
     <AnimatePresence>
       {open && (
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
@@ -117,6 +120,7 @@ export default function QuickProductModal({ open, onClose, onCreated }: QuickPro
           </motion.div>
         </motion.div>
       )}
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body
   );
 }

--- a/sweet-rebuild-suite-main/src/components/SearchableSelect.tsx
+++ b/sweet-rebuild-suite-main/src/components/SearchableSelect.tsx
@@ -107,7 +107,7 @@ export default function SearchableSelect({
           !selectedOption && "text-muted-foreground"
         )}
       >
-        <span className="truncate text-[13px]">
+        <span className="truncate text-[13px]" title={selectedOption ? selectedOption.label : placeholder}>
           {selectedOption ? selectedOption.label : placeholder}
         </span>
         <ChevronDown className={cn("w-3.5 h-3.5 text-muted-foreground shrink-0 transition-transform", isOpen && "rotate-180")} />
@@ -150,7 +150,7 @@ export default function SearchableSelect({
                     opt.value === value && "font-semibold text-primary"
                   )}
                 >
-                  <span className="truncate">{opt.label}</span>
+                  <span className="truncate" title={opt.label}>{opt.label}</span>
                   {opt.sublabel && <span className="text-[10px] text-muted-foreground font-mono ml-2 shrink-0">{opt.sublabel}</span>}
                 </div>
               ))

--- a/sweet-rebuild-suite-main/src/components/mobile/MobileFilterSheet.tsx
+++ b/sweet-rebuild-suite-main/src/components/mobile/MobileFilterSheet.tsx
@@ -1,4 +1,5 @@
 import { AnimatePresence, motion } from "framer-motion";
+import { createPortal } from "react-dom";
 import { X, SlidersHorizontal } from "lucide-react";
 
 interface FilterOption {
@@ -17,7 +18,9 @@ interface Props {
 }
 
 export default function MobileFilterSheet({ open, onOpenChange, filters, onClear, title = "Filters" }: Props) {
-  return (
+  // Portal to <body>: a transformed ancestor (page transition mid-flight)
+  // otherwise becomes the containing block for this fixed overlay.
+  return createPortal(
     <AnimatePresence>
       {open && (
         <>
@@ -81,6 +84,7 @@ export default function MobileFilterSheet({ open, onOpenChange, filters, onClear
           </motion.div>
         </>
       )}
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body
   );
 }

--- a/sweet-rebuild-suite-main/src/components/mobile/MobileMoreDrawer.tsx
+++ b/sweet-rebuild-suite-main/src/components/mobile/MobileMoreDrawer.tsx
@@ -1,4 +1,5 @@
 import { Link, useLocation, useNavigate } from "react-router-dom";
+import { createPortal } from "react-dom";
 import { AnimatePresence, motion } from "framer-motion";
 import {
   Building2, BarChart3, Calculator, HardDrive, Settings, History, LogOut, X, User, FileText, Users, Truck, ReceiptText } from "lucide-react";
@@ -31,7 +32,9 @@ export default function MobileMoreDrawer({ open, onOpenChange }: Props) {
 
   const isActive = (href: string) => location.pathname.startsWith(href);
 
-  return (
+  // Portal to <body>: a transformed ancestor (page transition mid-flight)
+  // otherwise becomes the containing block for this fixed overlay.
+  return createPortal(
     <AnimatePresence>
       {open && (
         <>
@@ -102,6 +105,7 @@ export default function MobileMoreDrawer({ open, onOpenChange }: Props) {
           </motion.div>
         </>
       )}
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body
   );
 }

--- a/sweet-rebuild-suite-main/src/components/mobile/easy/EasyMoreDrawer.tsx
+++ b/sweet-rebuild-suite-main/src/components/mobile/easy/EasyMoreDrawer.tsx
@@ -1,4 +1,5 @@
 import { Link, useLocation, useNavigate } from "react-router-dom";
+import { createPortal } from "react-dom";
 import { AnimatePresence, motion } from "framer-motion";
 import { Settings, LogOut, X, Wrench, User, ReceiptText } from "lucide-react";
 import { cn } from "@/utils/utils";
@@ -16,7 +17,9 @@ export default function EasyMoreDrawer({ open, onOpenChange }: Props) {
   const { setMobileMode } = useMobileMode();
   const { logout: authLogout } = useAuth();
 
-  return (
+  // Portal to <body>: a transformed ancestor (page transition mid-flight)
+  // otherwise becomes the containing block for this fixed overlay.
+  return createPortal(
     <AnimatePresence>
       {open && (
         <>
@@ -137,6 +140,7 @@ export default function EasyMoreDrawer({ open, onOpenChange }: Props) {
           </motion.div>
         </>
       )}
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body
   );
 }

--- a/sweet-rebuild-suite-main/src/hooks/useInwardBills.ts
+++ b/sweet-rebuild-suite-main/src/hooks/useInwardBills.ts
@@ -8,6 +8,7 @@ export interface InwardSupplier {
 }
 
 export interface InwardBillRow {
+  payment_mode?: string; // "bank" | "cash" | "credit" | "mixed" | "" — not recorded
   id: number;
   invoice_number: string;
   invoice_date: string;

--- a/sweet-rebuild-suite-main/src/pages/BusinessDetail.tsx
+++ b/sweet-rebuild-suite-main/src/pages/BusinessDetail.tsx
@@ -184,7 +184,7 @@ export default function BusinessDetail() {
               {topCustomers.map((c) => (
                 <Link key={c.id} to={`/billing/customer/${c.id}`} className="flex items-center gap-3 p-3 rounded-xl border border-border/40 hover:bg-secondary/20 group">
                   <div className="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center text-primary text-[11px] font-bold shrink-0">{c.name.split(" ").map((w) => w[0]).join("").slice(0, 2)}</div>
-                  <div className="flex-1 min-w-0"><p className="text-[12px] font-semibold text-foreground truncate">{c.name}</p><p className="text-[10px] text-muted-foreground">{c.invCount} inv</p></div>
+                  <div className="flex-1 min-w-0"><p className="text-[12px] font-semibold text-foreground truncate" title={c.name}>{c.name}</p><p className="text-[10px] text-muted-foreground">{c.invCount} inv</p></div>
                   <p className="text-[11px] font-bold text-success tabular-nums">{formatCurrency(c.revenue)}</p>
                 </Link>
               ))}

--- a/sweet-rebuild-suite-main/src/pages/Dashboard.tsx
+++ b/sweet-rebuild-suite-main/src/pages/Dashboard.tsx
@@ -341,7 +341,7 @@ export default function Dashboard() {
                   )}>{inv.type}</span>
                 </div>
                 <div className="flex items-center justify-between gap-2">
-                  <p className="text-[11px] text-muted-foreground truncate">{inv.businessName}</p>
+                  <p className="text-[11px] text-muted-foreground truncate" title={inv.businessName}>{inv.businessName}</p>
                   {/* Compact (₹2.86L) so a long business name + ₹1,39,363.59
                       don't wrap or collide on a 375px screen. Full value in
                       the title for hover/long-press access. */}
@@ -363,7 +363,7 @@ export default function Dashboard() {
               <Link key={c.id} to={`/billing/customer/${c.id}`} className="flex items-center gap-3">
                 <span className="w-6 h-6 rounded-md bg-primary/10 flex items-center justify-center text-primary text-[10px] font-bold shrink-0">{i + 1}</span>
                 <div className="flex-1 min-w-0">
-                  <p className="text-[12px] font-medium text-foreground truncate">{c.name}</p>
+                  <p className="text-[12px] font-medium text-foreground truncate" title={c.name}>{c.name}</p>
                 </div>
                 <span className="text-[12px] font-bold text-foreground tabular-nums shrink-0" title={formatCurrency(c.total)}>{formatCompactCurrency(c.total)}</span>
               </Link>
@@ -628,13 +628,13 @@ export default function Dashboard() {
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center justify-between gap-2">
                       {link ? (
-                        <Link to={link} className="text-[13px] font-medium text-foreground hover:text-primary transition-colors truncate">{name}</Link>
+                        <Link to={link} className="text-[13px] font-medium text-foreground hover:text-primary transition-colors truncate" title={name}>{name}</Link>
                       ) : (
-                        <span className="text-[13px] font-medium text-foreground truncate">{name}</span>
+                        <span className="text-[13px] font-medium text-foreground truncate" title={name}>{name}</span>
                       )}
                       <span className="text-[10px] text-muted-foreground shrink-0">{time}</span>
                     </div>
-                    <p className="text-[11px] text-muted-foreground mt-0.5 truncate">{isAudit ? label : detail}</p>
+                    <p className="text-[11px] text-muted-foreground mt-0.5 truncate" title={isAudit ? label : detail}>{isAudit ? label : detail}</p>
                   </div>
                 </div>
               );
@@ -665,7 +665,7 @@ export default function Dashboard() {
                 <span className="w-7 h-7 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center text-primary text-[11px] font-bold shrink-0">{i + 1}</span>
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center justify-between mb-1.5">
-                    <span className="text-[13px] font-medium text-foreground group-hover:text-primary transition-colors truncate">{c.name}</span>
+                    <span className="text-[13px] font-medium text-foreground group-hover:text-primary transition-colors truncate" title={c.name}>{c.name}</span>
                     <span className="text-[12px] font-semibold text-muted-foreground tabular-nums ml-2">{formatCurrency(c.total)}</span>
                   </div>
                   <div className="w-full h-1 bg-secondary/40 rounded-full overflow-hidden">
@@ -694,7 +694,7 @@ export default function Dashboard() {
               <Link key={p.id} to={`/billing/product/${p.id}`} className="flex items-center gap-3 group p-2 -mx-2 rounded-xl hover:bg-secondary/20 transition-colors">
                 <span className="w-7 h-7 rounded-lg bg-success/10 border border-success/20 flex items-center justify-center text-success text-[11px] font-bold shrink-0">{i + 1}</span>
                 <div className="flex-1 min-w-0">
-                  <p className="text-[13px] font-medium text-foreground group-hover:text-primary transition-colors truncate">{p.name}</p>
+                  <p className="text-[13px] font-medium text-foreground group-hover:text-primary transition-colors truncate" title={p.name}>{p.name}</p>
                   {p.hsn && <p className="text-[11px] text-muted-foreground">HSN: {p.hsn}{p.hsnVariants > 1 ? ` +${p.hsnVariants - 1} more` : ""}</p>}
                   {!p.hsn && <p className="text-[11px] text-muted-foreground/50 italic">No HSN</p>}
                 </div>

--- a/sweet-rebuild-suite-main/src/pages/ImportPage.tsx
+++ b/sweet-rebuild-suite-main/src/pages/ImportPage.tsx
@@ -1151,7 +1151,7 @@ export default function ImportPage({ type }: ImportPageProps) {
                               </span>
                             </td>
                             <td className="px-2 py-1.5 font-medium text-primary">{inv.invoiceNumber}</td>
-                            <td className="px-2 py-1.5 tabular-nums">
+                            <td className="px-2 py-1.5 tabular-nums whitespace-nowrap">
                               {editingIdx === idx ? (
                                 <input type="date" value={editForm.date} onChange={(e) => setEditForm(p => ({ ...p, date: e.target.value }))}
                                   className="w-[110px] px-1 py-0.5 rounded bg-input border border-border text-[11px]" />
@@ -1164,13 +1164,13 @@ export default function ImportPage({ type }: ImportPageProps) {
                                 <input type="text" value={editForm.party} onChange={(e) => setEditForm(p => ({ ...p, party: e.target.value }))}
                                   className="w-full px-1 py-0.5 rounded bg-input border border-border text-[11px]" />
                               ) : (
-                                <>
-                                  {inv.customerName}
-                                  {v.customerMatch && <span className="text-[9px] text-success ml-1">(matched)</span>}
-                                </>
+                                <span className="inline-flex items-center gap-1 min-w-0">
+                                  <span className="truncate">{inv.customerName}</span>
+                                  {v.customerMatch && <Check className="w-3 h-3 text-success shrink-0" aria-label="Matched to an existing customer" />}
+                                </span>
                               )}
                             </td>
-                            <td className="px-2 py-1.5 font-mono text-[10px] truncate max-w-[100px]" title={inv.customerGST}>
+                            <td className="px-2 py-1.5 font-mono text-[10px] whitespace-nowrap">
                               {editingIdx === idx ? (
                                 <input type="text" value={editForm.gst} onChange={(e) => setEditForm(p => ({ ...p, gst: e.target.value }))}
                                   className="w-full px-1 py-0.5 rounded bg-input border border-border text-[10px] font-mono" placeholder="GST Number" />
@@ -1178,11 +1178,11 @@ export default function ImportPage({ type }: ImportPageProps) {
                                 inv.customerGST || "-"
                               )}
                             </td>
-                            <td className="px-2 py-1.5 truncate max-w-[100px]" title={inv.firmName}>
-                              {inv.firmName}
-                              {v.businessMatch && (
-                                <span className="text-[9px] text-success ml-1">(ok)</span>
-                              )}
+                            <td className="px-2 py-1.5 max-w-[100px]" title={inv.firmName}>
+                              <span className="inline-flex items-center gap-1 min-w-0">
+                                <span className="truncate">{inv.firmName}</span>
+                                {v.businessMatch && <Check className="w-3 h-3 text-success shrink-0" aria-label="Firm matched" />}
+                              </span>
                             </td>
                             <td className="px-2 py-1.5 text-center">
                               {editingIdx === idx ? (
@@ -1194,12 +1194,16 @@ export default function ImportPage({ type }: ImportPageProps) {
                                     className="w-[60px] px-1 py-0.5 rounded bg-input border border-border text-[11px] tabular-nums" step="0.01" />
                                 </div>
                               ) : (
-                                <>
-                                  {inv.items.length}
-                                  <span className="text-[9px] text-muted-foreground ml-0.5">
-                                    ({inv.items.map(i => `${i.qty}${i.unit || "gms"}`).join(", ")})
-                                  </span>
-                                </>
+                                (() => {
+                                  const totalQty = inv.items.reduce((q, i) => q + (i.qty || 0), 0);
+                                  const units = Array.from(new Set(inv.items.map(i => i.unit || "gms")));
+                                  const qtyLabel = units.length === 1 ? `${roundAmount(totalQty)} ${units[0]}` : `${inv.items.length} units`;
+                                  return (
+                                    <span className="whitespace-nowrap" title={inv.items.map(i => `${i.qty} ${i.unit || "gms"} @ ₹${i.rate}`).join("\n")}>
+                                      {inv.items.length} · <span className="text-muted-foreground">{qtyLabel}</span>
+                                    </span>
+                                  );
+                                })()
                               )}
                             </td>
                             <td className="px-2 py-1.5 text-right tabular-nums">

--- a/sweet-rebuild-suite-main/src/pages/InvoiceForm.tsx
+++ b/sweet-rebuild-suite-main/src/pages/InvoiceForm.tsx
@@ -736,7 +736,7 @@ export default function InvoiceForm({ mode }: InvoiceFormProps) {
                   if (item.qty === 0 && item.rate === 0 && !product) return null;
                   return (
                     <div key={item._key} className="space-y-1.5 pb-2 border-b border-border/30">
-                      {product && <div className="text-[12px] font-medium text-foreground truncate">{product.name}</div>}
+                      {product && <div className="text-[12px] font-medium text-foreground truncate" title={product.name}>{product.name}</div>}
                       <div className="flex justify-between"><span className="text-muted-foreground">Qty</span><span className="text-foreground">{item.qty} {item.unit}</span></div>
                       <div className="flex justify-between"><span className="text-muted-foreground">Rate</span><span className="text-foreground">{formatCurrency(item.rate)}/{item.unit}</span></div>
                     </div>

--- a/sweet-rebuild-suite-main/src/pages/InwardBills.tsx
+++ b/sweet-rebuild-suite-main/src/pages/InwardBills.tsx
@@ -141,7 +141,7 @@ export default function InwardBills() {
                 >
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0">
-                      <p className="font-medium truncate">{b.supplier?.name || "—"}</p>
+                      <p className="font-medium truncate" title={b.supplier?.name || undefined}>{b.supplier?.name || "—"}</p>
                       <p className="text-xs text-muted-foreground truncate">
                         #{b.invoice_number} · {formatDate(b.invoice_date)}
                       </p>
@@ -154,7 +154,7 @@ export default function InwardBills() {
                     </div>
                   </div>
                   <div className="flex items-center justify-between gap-2 text-[11px] text-muted-foreground">
-                    <span className="truncate">{b.business_name}</span>
+                    <span className="truncate" title={b.business_name}>{b.business_name}</span>
                     <span className="flex items-center gap-2 shrink-0">
                       <span className="tabular-nums">taxable {formatCurrency(Number(b.taxable))}</span>
                       {b.has_file && <Paperclip className="h-3.5 w-3.5" />}
@@ -214,7 +214,7 @@ export default function InwardBills() {
                   >
                     <TableCell className="font-medium">{b.invoice_number}</TableCell>
                     <TableCell>
-                      <div className="max-w-[220px] truncate">{b.supplier?.name || "—"}</div>
+                      <div className="max-w-[220px] truncate" title={b.supplier?.name || undefined}>{b.supplier?.name || "—"}</div>
                       <div className="text-xs text-muted-foreground">{b.supplier?.gst_number || ""}</div>
                     </TableCell>
                     <TableCell className="text-sm">{b.business_name}</TableCell>

--- a/sweet-rebuild-suite-main/src/pages/Reports.tsx
+++ b/sweet-rebuild-suite-main/src/pages/Reports.tsx
@@ -468,7 +468,7 @@ export default function Reports() {
                     </div>
                     <div className="flex-1 min-w-0">
                       <p className={cn("text-[12px] font-display font-semibold truncate", l.color)}>{l.label}</p>
-                      <p className="text-[10px] text-muted-foreground truncate">{l.desc}</p>
+                      <p className="text-[10px] text-muted-foreground truncate" title={l.desc}>{l.desc}</p>
                     </div>
                     <ExternalLink className="w-3 h-3 text-muted-foreground/60 shrink-0" />
                   </div>

--- a/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.ts
+++ b/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.ts
@@ -338,6 +338,7 @@ export interface ImportReadyInvoice {
   invoice_date: string;
   customerName: string;
   customerGST: string;
+  paymentMode?: string; // "bank" | "cash" | "credit" | "mixed" | "" — from the optional Payment column
   type: "OUTWARD" | "INWARD";
   firmName: string;
   firmGSTIN: string;


### PR DESCRIPTION
## Fixes main's red Typecheck (and explains it)
The payment-mode commit missed two type declarations — `InwardBillRow.payment_mode` and `ImportReadyInvoice.paymentMode`. CI's "Typecheck frontend" runs `tsc -p tsconfig.app.json` (strict) while the local gate had been running the looser root config, so this slipped through locally but failed on main after the #133 merge. Both fields exist at runtime and vite doesn't typecheck, so the released v2.0.3 images work — this was CI-only. Fixed and verified against the same config CI uses.

## Recovers the UI sweep stranded by the merge race
The full-app sweep commit reached the #133 branch minutes after the merge, so it never landed on main. Re-shipped here: ImportPage preview-table fixes (no-wrap dates, icon match markers, full GSTINs, `N · qty` items), five overlay components portaled to `<body>`, and tooltips on every truncation the 39-route audit flagged (Dashboard, Reports, inward register, BusinessDetail, InvoiceForm, SearchableSelect).

Strict tsc clean · 56 FE tests pass · production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
