### PR TITLE
Phone-first billing: live math, review-before-save, one-tap share + reconciled invoice list

### DIFF
--- a/billing/api/views.py
+++ b/billing/api/views.py
@@ -1305,6 +1305,8 @@ class InvoiceViewSet(AuditLogMixin, viewsets.ModelViewSet):
                 Decimal("0.00"),
             ),
             count=Count("id"),
+            outward_count=Count("id", filter=Q(type_of_invoice="outward")),
+            inward_count=Count("id", filter=Q(type_of_invoice="inward")),
         )
         tax_totals = LineItem.objects.filter(
             invoice_id__in=queryset.values("id")
@@ -1354,6 +1356,8 @@ class InvoiceViewSet(AuditLogMixin, viewsets.ModelViewSet):
             "tax": float(totals["outward_tax"]),
             "inward_tax": float(totals["inward_tax"]),
             "count": totals["count"],
+            "outward_count": totals["outward_count"],
+            "inward_count": totals["inward_count"],
         }
         # Per-month output tax, aggregated on LineItem directly — joining the
         # tax into monthly_raw's invoice-level query would re-introduce the

--- a/billing/tests/test_dashboard_stats.py
+++ b/billing/tests/test_dashboard_stats.py
@@ -169,3 +169,10 @@ class MonthlyTaxTest(BaseAPITestCase):
             for li in LineItem.objects.filter(invoice__type_of_invoice=INVOICE_TYPE_OUTWARD)
         )
         self.assertAlmostEqual(sum(m["outward_tax"] for m in months.values()), db_total, places=2)
+
+    def test_per_direction_counts_match_total(self):
+        """Cards pair full-period money with counts — same base, or they lie."""
+        r = self.client.get(reverse("invoice-stats"))
+        t = r.data["totals"]
+        self.assertEqual(t["outward_count"] + t["inward_count"], t["count"])
+        self.assertGreaterEqual(t["outward_count"], 0)

--- a/e2e-tests/tests/money-paths.spec.js
+++ b/e2e-tests/tests/money-paths.spec.js
@@ -64,6 +64,9 @@ test.describe('Outward invoice — tax heads land correctly', () => {
     const create = page.waitForResponse(
       (r) => r.url().includes('/api/invoices/') && r.request().method() === 'POST');
     await page.getByRole('button', { name: 'Create Invoice' }).click();
+    // The form now opens a review-&-confirm sheet before saving — the POST
+    // fires only from its Confirm button.
+    await page.getByRole('button', { name: /Confirm & Save/ }).click();
     const resp = await create;
     expect(resp.status(), await resp.text()).toBe(201);
     const { id } = await resp.json();
@@ -91,6 +94,9 @@ test.describe('Outward invoice — tax heads land correctly', () => {
     const create = page.waitForResponse(
       (r) => r.url().includes('/api/invoices/') && r.request().method() === 'POST');
     await page.getByRole('button', { name: 'Create Invoice' }).click();
+    // The form now opens a review-&-confirm sheet before saving — the POST
+    // fires only from its Confirm button.
+    await page.getByRole('button', { name: /Confirm & Save/ }).click();
     const resp = await create;
     expect(resp.status(), await resp.text()).toBe(201);
     const { id } = await resp.json();

--- a/sweet-rebuild-suite-main/src/components/QuickCustomerModal.tsx
+++ b/sweet-rebuild-suite-main/src/components/QuickCustomerModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { useGstinLookup } from "@/hooks/useGstinLookup";
 import { validateGstin } from "@/utils/gstin";
 import GstinStatus from "@/components/GstinStatus";
@@ -107,7 +108,9 @@ export default function QuickCustomerModal({ open, onClose, onCreated }: QuickCu
     setSubmitting(false);
   };
 
-  return (
+  // Portal to <body>: a transformed ancestor (page transition mid-flight)
+  // otherwise becomes the containing block for this fixed overlay.
+  return createPortal(
     <AnimatePresence>
       {open && (
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
@@ -177,7 +180,8 @@ export default function QuickCustomerModal({ open, onClose, onCreated }: QuickCu
           </motion.div>
         </motion.div>
       )}
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body
   );
 }
 

--- a/sweet-rebuild-suite-main/src/components/QuickProductModal.tsx
+++ b/sweet-rebuild-suite-main/src/components/QuickProductModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { X, Package, Save, Hash, Percent, FileText } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
@@ -50,7 +51,9 @@ export default function QuickProductModal({ open, onClose, onCreated }: QuickPro
     setErrors({});
   };
 
-  return (
+  // Portal to <body>: a transformed ancestor (page transition mid-flight)
+  // otherwise becomes the containing block for this fixed overlay.
+  return createPortal(
     <AnimatePresence>
       {open && (
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
@@ -117,6 +120,7 @@ export default function QuickProductModal({ open, onClose, onCreated }: QuickPro
           </motion.div>
         </motion.div>
       )}
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body
   );
 }

--- a/sweet-rebuild-suite-main/src/components/SearchableSelect.tsx
+++ b/sweet-rebuild-suite-main/src/components/SearchableSelect.tsx
@@ -107,7 +107,7 @@ export default function SearchableSelect({
           !selectedOption && "text-muted-foreground"
         )}
       >
-        <span className="truncate text-[13px]">
+        <span className="truncate text-[13px]" title={selectedOption ? selectedOption.label : placeholder}>
           {selectedOption ? selectedOption.label : placeholder}
         </span>
         <ChevronDown className={cn("w-3.5 h-3.5 text-muted-foreground shrink-0 transition-transform", isOpen && "rotate-180")} />
@@ -150,7 +150,7 @@ export default function SearchableSelect({
                     opt.value === value && "font-semibold text-primary"
                   )}
                 >
-                  <span className="truncate">{opt.label}</span>
+                  <span className="truncate" title={opt.label}>{opt.label}</span>
                   {opt.sublabel && <span className="text-[10px] text-muted-foreground font-mono ml-2 shrink-0">{opt.sublabel}</span>}
                 </div>
               ))

--- a/sweet-rebuild-suite-main/src/components/mobile/MobileFilterSheet.tsx
+++ b/sweet-rebuild-suite-main/src/components/mobile/MobileFilterSheet.tsx
@@ -1,4 +1,5 @@
 import { AnimatePresence, motion } from "framer-motion";
+import { createPortal } from "react-dom";
 import { X, SlidersHorizontal } from "lucide-react";
 
 interface FilterOption {
@@ -17,7 +18,9 @@ interface Props {
 }
 
 export default function MobileFilterSheet({ open, onOpenChange, filters, onClear, title = "Filters" }: Props) {
-  return (
+  // Portal to <body>: a transformed ancestor (page transition mid-flight)
+  // otherwise becomes the containing block for this fixed overlay.
+  return createPortal(
     <AnimatePresence>
       {open && (
         <>
@@ -81,6 +84,7 @@ export default function MobileFilterSheet({ open, onOpenChange, filters, onClear
           </motion.div>
         </>
       )}
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body
   );
 }

--- a/sweet-rebuild-suite-main/src/components/mobile/MobileMoreDrawer.tsx
+++ b/sweet-rebuild-suite-main/src/components/mobile/MobileMoreDrawer.tsx
@@ -1,4 +1,5 @@
 import { Link, useLocation, useNavigate } from "react-router-dom";
+import { createPortal } from "react-dom";
 import { AnimatePresence, motion } from "framer-motion";
 import {
   Building2, BarChart3, Calculator, HardDrive, Settings, History, LogOut, X, User, FileText, Users, Truck, ReceiptText } from "lucide-react";
@@ -31,7 +32,9 @@ export default function MobileMoreDrawer({ open, onOpenChange }: Props) {
 
   const isActive = (href: string) => location.pathname.startsWith(href);
 
-  return (
+  // Portal to <body>: a transformed ancestor (page transition mid-flight)
+  // otherwise becomes the containing block for this fixed overlay.
+  return createPortal(
     <AnimatePresence>
       {open && (
         <>
@@ -102,6 +105,7 @@ export default function MobileMoreDrawer({ open, onOpenChange }: Props) {
           </motion.div>
         </>
       )}
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body
   );
 }

--- a/sweet-rebuild-suite-main/src/components/mobile/easy/EasyMoreDrawer.tsx
+++ b/sweet-rebuild-suite-main/src/components/mobile/easy/EasyMoreDrawer.tsx
@@ -1,4 +1,5 @@
 import { Link, useLocation, useNavigate } from "react-router-dom";
+import { createPortal } from "react-dom";
 import { AnimatePresence, motion } from "framer-motion";
 import { Settings, LogOut, X, Wrench, User, ReceiptText } from "lucide-react";
 import { cn } from "@/utils/utils";
@@ -16,7 +17,9 @@ export default function EasyMoreDrawer({ open, onOpenChange }: Props) {
   const { setMobileMode } = useMobileMode();
   const { logout: authLogout } = useAuth();
 
-  return (
+  // Portal to <body>: a transformed ancestor (page transition mid-flight)
+  // otherwise becomes the containing block for this fixed overlay.
+  return createPortal(
     <AnimatePresence>
       {open && (
         <>
@@ -137,6 +140,7 @@ export default function EasyMoreDrawer({ open, onOpenChange }: Props) {
           </motion.div>
         </>
       )}
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body
   );
 }

--- a/sweet-rebuild-suite-main/src/hooks/useDataStore.ts
+++ b/sweet-rebuild-suite-main/src/hooks/useDataStore.ts
@@ -95,6 +95,8 @@ export interface DashboardStats {
     count: number;
     tax: number;
     inward_tax: number;
+    outward_count?: number;
+    inward_count?: number;
   };
   monthly: any[];
   tax_distribution?: {

--- a/sweet-rebuild-suite-main/src/hooks/useInwardBills.ts
+++ b/sweet-rebuild-suite-main/src/hooks/useInwardBills.ts
@@ -8,6 +8,7 @@ export interface InwardSupplier {
 }
 
 export interface InwardBillRow {
+  payment_mode?: string; // "bank" | "cash" | "credit" | "mixed" | "" — not recorded
   id: number;
   invoice_number: string;
   invoice_date: string;

--- a/sweet-rebuild-suite-main/src/pages/BusinessDetail.tsx
+++ b/sweet-rebuild-suite-main/src/pages/BusinessDetail.tsx
@@ -184,7 +184,7 @@ export default function BusinessDetail() {
               {topCustomers.map((c) => (
                 <Link key={c.id} to={`/billing/customer/${c.id}`} className="flex items-center gap-3 p-3 rounded-xl border border-border/40 hover:bg-secondary/20 group">
                   <div className="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center text-primary text-[11px] font-bold shrink-0">{c.name.split(" ").map((w) => w[0]).join("").slice(0, 2)}</div>
-                  <div className="flex-1 min-w-0"><p className="text-[12px] font-semibold text-foreground truncate">{c.name}</p><p className="text-[10px] text-muted-foreground">{c.invCount} inv</p></div>
+                  <div className="flex-1 min-w-0"><p className="text-[12px] font-semibold text-foreground truncate" title={c.name}>{c.name}</p><p className="text-[10px] text-muted-foreground">{c.invCount} inv</p></div>
                   <p className="text-[11px] font-bold text-success tabular-nums">{formatCurrency(c.revenue)}</p>
                 </Link>
               ))}

--- a/sweet-rebuild-suite-main/src/pages/Dashboard.tsx
+++ b/sweet-rebuild-suite-main/src/pages/Dashboard.tsx
@@ -341,7 +341,7 @@ export default function Dashboard() {
                   )}>{inv.type}</span>
                 </div>
                 <div className="flex items-center justify-between gap-2">
-                  <p className="text-[11px] text-muted-foreground truncate">{inv.businessName}</p>
+                  <p className="text-[11px] text-muted-foreground truncate" title={inv.businessName}>{inv.businessName}</p>
                   {/* Compact (₹2.86L) so a long business name + ₹1,39,363.59
                       don't wrap or collide on a 375px screen. Full value in
                       the title for hover/long-press access. */}
@@ -363,7 +363,7 @@ export default function Dashboard() {
               <Link key={c.id} to={`/billing/customer/${c.id}`} className="flex items-center gap-3">
                 <span className="w-6 h-6 rounded-md bg-primary/10 flex items-center justify-center text-primary text-[10px] font-bold shrink-0">{i + 1}</span>
                 <div className="flex-1 min-w-0">
-                  <p className="text-[12px] font-medium text-foreground truncate">{c.name}</p>
+                  <p className="text-[12px] font-medium text-foreground truncate" title={c.name}>{c.name}</p>
                 </div>
                 <span className="text-[12px] font-bold text-foreground tabular-nums shrink-0" title={formatCurrency(c.total)}>{formatCompactCurrency(c.total)}</span>
               </Link>
@@ -628,13 +628,13 @@ export default function Dashboard() {
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center justify-between gap-2">
                       {link ? (
-                        <Link to={link} className="text-[13px] font-medium text-foreground hover:text-primary transition-colors truncate">{name}</Link>
+                        <Link to={link} className="text-[13px] font-medium text-foreground hover:text-primary transition-colors truncate" title={name}>{name}</Link>
                       ) : (
-                        <span className="text-[13px] font-medium text-foreground truncate">{name}</span>
+                        <span className="text-[13px] font-medium text-foreground truncate" title={name}>{name}</span>
                       )}
                       <span className="text-[10px] text-muted-foreground shrink-0">{time}</span>
                     </div>
-                    <p className="text-[11px] text-muted-foreground mt-0.5 truncate">{isAudit ? label : detail}</p>
+                    <p className="text-[11px] text-muted-foreground mt-0.5 truncate" title={isAudit ? label : detail}>{isAudit ? label : detail}</p>
                   </div>
                 </div>
               );
@@ -665,7 +665,7 @@ export default function Dashboard() {
                 <span className="w-7 h-7 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center text-primary text-[11px] font-bold shrink-0">{i + 1}</span>
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center justify-between mb-1.5">
-                    <span className="text-[13px] font-medium text-foreground group-hover:text-primary transition-colors truncate">{c.name}</span>
+                    <span className="text-[13px] font-medium text-foreground group-hover:text-primary transition-colors truncate" title={c.name}>{c.name}</span>
                     <span className="text-[12px] font-semibold text-muted-foreground tabular-nums ml-2">{formatCurrency(c.total)}</span>
                   </div>
                   <div className="w-full h-1 bg-secondary/40 rounded-full overflow-hidden">
@@ -694,7 +694,7 @@ export default function Dashboard() {
               <Link key={p.id} to={`/billing/product/${p.id}`} className="flex items-center gap-3 group p-2 -mx-2 rounded-xl hover:bg-secondary/20 transition-colors">
                 <span className="w-7 h-7 rounded-lg bg-success/10 border border-success/20 flex items-center justify-center text-success text-[11px] font-bold shrink-0">{i + 1}</span>
                 <div className="flex-1 min-w-0">
-                  <p className="text-[13px] font-medium text-foreground group-hover:text-primary transition-colors truncate">{p.name}</p>
+                  <p className="text-[13px] font-medium text-foreground group-hover:text-primary transition-colors truncate" title={p.name}>{p.name}</p>
                   {p.hsn && <p className="text-[11px] text-muted-foreground">HSN: {p.hsn}{p.hsnVariants > 1 ? ` +${p.hsnVariants - 1} more` : ""}</p>}
                   {!p.hsn && <p className="text-[11px] text-muted-foreground/50 italic">No HSN</p>}
                 </div>

--- a/sweet-rebuild-suite-main/src/pages/ImportPage.tsx
+++ b/sweet-rebuild-suite-main/src/pages/ImportPage.tsx
@@ -1151,7 +1151,7 @@ export default function ImportPage({ type }: ImportPageProps) {
                               </span>
                             </td>
                             <td className="px-2 py-1.5 font-medium text-primary">{inv.invoiceNumber}</td>
-                            <td className="px-2 py-1.5 tabular-nums">
+                            <td className="px-2 py-1.5 tabular-nums whitespace-nowrap">
                               {editingIdx === idx ? (
                                 <input type="date" value={editForm.date} onChange={(e) => setEditForm(p => ({ ...p, date: e.target.value }))}
                                   className="w-[110px] px-1 py-0.5 rounded bg-input border border-border text-[11px]" />
@@ -1164,13 +1164,13 @@ export default function ImportPage({ type }: ImportPageProps) {
                                 <input type="text" value={editForm.party} onChange={(e) => setEditForm(p => ({ ...p, party: e.target.value }))}
                                   className="w-full px-1 py-0.5 rounded bg-input border border-border text-[11px]" />
                               ) : (
-                                <>
-                                  {inv.customerName}
-                                  {v.customerMatch && <span className="text-[9px] text-success ml-1">(matched)</span>}
-                                </>
+                                <span className="inline-flex items-center gap-1 min-w-0">
+                                  <span className="truncate">{inv.customerName}</span>
+                                  {v.customerMatch && <Check className="w-3 h-3 text-success shrink-0" aria-label="Matched to an existing customer" />}
+                                </span>
                               )}
                             </td>
-                            <td className="px-2 py-1.5 font-mono text-[10px] truncate max-w-[100px]" title={inv.customerGST}>
+                            <td className="px-2 py-1.5 font-mono text-[10px] whitespace-nowrap">
                               {editingIdx === idx ? (
                                 <input type="text" value={editForm.gst} onChange={(e) => setEditForm(p => ({ ...p, gst: e.target.value }))}
                                   className="w-full px-1 py-0.5 rounded bg-input border border-border text-[10px] font-mono" placeholder="GST Number" />
@@ -1178,11 +1178,11 @@ export default function ImportPage({ type }: ImportPageProps) {
                                 inv.customerGST || "-"
                               )}
                             </td>
-                            <td className="px-2 py-1.5 truncate max-w-[100px]" title={inv.firmName}>
-                              {inv.firmName}
-                              {v.businessMatch && (
-                                <span className="text-[9px] text-success ml-1">(ok)</span>
-                              )}
+                            <td className="px-2 py-1.5 max-w-[100px]" title={inv.firmName}>
+                              <span className="inline-flex items-center gap-1 min-w-0">
+                                <span className="truncate">{inv.firmName}</span>
+                                {v.businessMatch && <Check className="w-3 h-3 text-success shrink-0" aria-label="Firm matched" />}
+                              </span>
                             </td>
                             <td className="px-2 py-1.5 text-center">
                               {editingIdx === idx ? (
@@ -1194,12 +1194,16 @@ export default function ImportPage({ type }: ImportPageProps) {
                                     className="w-[60px] px-1 py-0.5 rounded bg-input border border-border text-[11px] tabular-nums" step="0.01" />
                                 </div>
                               ) : (
-                                <>
-                                  {inv.items.length}
-                                  <span className="text-[9px] text-muted-foreground ml-0.5">
-                                    ({inv.items.map(i => `${i.qty}${i.unit || "gms"}`).join(", ")})
-                                  </span>
-                                </>
+                                (() => {
+                                  const totalQty = inv.items.reduce((q, i) => q + (i.qty || 0), 0);
+                                  const units = Array.from(new Set(inv.items.map(i => i.unit || "gms")));
+                                  const qtyLabel = units.length === 1 ? `${roundAmount(totalQty)} ${units[0]}` : `${inv.items.length} units`;
+                                  return (
+                                    <span className="whitespace-nowrap" title={inv.items.map(i => `${i.qty} ${i.unit || "gms"} @ ₹${i.rate}`).join("\n")}>
+                                      {inv.items.length} · <span className="text-muted-foreground">{qtyLabel}</span>
+                                    </span>
+                                  );
+                                })()
                               )}
                             </td>
                             <td className="px-2 py-1.5 text-right tabular-nums">

--- a/sweet-rebuild-suite-main/src/pages/InvoiceDetail.tsx
+++ b/sweet-rebuild-suite-main/src/pages/InvoiceDetail.tsx
@@ -531,6 +531,7 @@ export default function InvoiceDetail() {
               <div className="elevated-card rounded-2xl p-5 space-y-2.5">
                 <h3 className="text-[12px] font-semibold text-muted-foreground uppercase tracking-wider mb-3">Quick Actions</h3>
                 <Link to={printUrl} className="premium-btn-primary w-full text-[13px]"><Printer className="w-4 h-4" /> Print / PDF</Link>
+                <Link to={`${printUrl}?share=1`} className="premium-btn-outline w-full text-[13px]"><Share2 className="w-4 h-4" /> Share PDF</Link>
                 <button onClick={() => shareViaWhatsApp(inv, customer?.mobile_number)} className="premium-btn-outline w-full text-[13px] border-success/30 text-success"><MessageCircle className="w-4 h-4" /> WhatsApp {customer?.mobile_number ? `(${customer.mobile_number})` : ""}</button>
                 <Link to={printUrl} className="premium-btn-ghost w-full text-[13px]"><Download className="w-4 h-4" /> Download PDF</Link>
               </div>

--- a/sweet-rebuild-suite-main/src/pages/InvoiceForm.tsx
+++ b/sweet-rebuild-suite-main/src/pages/InvoiceForm.tsx
@@ -1,5 +1,6 @@
 import { logger } from "@/utils/logger";
 import { useState, useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
 import { useParams, useNavigate, Link, useLocation } from "react-router-dom";
 import { formatCurrency, itemUnits, itemUnitLabels, currentFY } from "@/utils/mockData";
 import DraftRestoreBanner from "@/components/DraftRestoreBanner";
@@ -375,15 +376,23 @@ export default function InvoiceForm({ mode }: InvoiceFormProps) {
   const completion = Math.round((completionFields.filter(Boolean).length / completionFields.length) * 100);
 
   const [isSaving, setIsSaving] = useState(false);
+  // Review-before-save: the calculator, absorbed. Submit opens the sheet;
+  // the actual save runs only from its Confirm button.
+  const [showReview, setShowReview] = useState(false);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    if (isSaving) return;
+    if (!form.businessId || !form.customerId) { toast({ title: "Missing fields", description: "Select business and customer.", variant: "destructive" }); return; }
+    if (items.some((it) => !it.productId)) { toast({ title: "Incomplete items", description: "Select a product for all line items.", variant: "destructive" }); return; }
+    setShowReview(true);
+  };
+
+  const performSave = async () => {
     // Guard against rapid double-clicks creating duplicate invoices.
     // setIsSaving is reset only inside the create/update branches below
     // (since they each navigate or set their own error state).
     if (isSaving) return;
-    if (!form.businessId || !form.customerId) { toast({ title: "Missing fields", description: "Select business and customer.", variant: "destructive" }); return; }
-    if (items.some((it) => !it.productId)) { toast({ title: "Incomplete items", description: "Select a product for all line items.", variant: "destructive" }); return; }
     setIsSaving(true);
     setDirty(false);
 
@@ -454,8 +463,10 @@ export default function InvoiceForm({ mode }: InvoiceFormProps) {
           message: `${form.invoiceNumber} · ${selectedCust?.name || "Customer"} · ${formatCurrency(total)}`,
         });
         const navId = created?.id ? String(created.id) : newId;
-        if (isMobile && mobileMode === "easy") {
-          navigate(`/billing/invoice/${navId}`);
+        if (isMobile) {
+          // Phone flow: land on the printable bill with the native share
+          // sheet already opening — save → WhatsApp in one motion.
+          navigate(`/billing/invoice/${navId}/print?share=1`);
         } else {
           navigate("/billing/invoice/list");
         }
@@ -658,10 +669,17 @@ export default function InvoiceForm({ mode }: InvoiceFormProps) {
                           placeholder="Search Product"
                         />
                         <div className="grid grid-cols-3 gap-2">
-                          <div><label className="text-[10px] text-muted-foreground uppercase">Qty</label><input type="number" value={item.qty} min={0.00001} step="0.00001" onChange={(e) => updateItem(i, "qty", Math.max(0, Number(e.target.value)))} className="premium-input h-9 w-full text-center" /></div>
-                          <div><label className="text-[10px] text-muted-foreground uppercase">Unit</label><select value={item.unit} onChange={(e) => updateItem(i, "unit", e.target.value)} className="premium-select h-9 w-full text-[11px]">{itemUnits.map((u) => <option key={u} value={u}>{u}</option>)}</select></div>
-                          <div><label className="text-[10px] text-muted-foreground uppercase">Rate (₹)</label><input type="number" value={item.rate} min={0} step="0.00001" onChange={(e) => updateItem(i, "rate", Math.max(0, Number(e.target.value)))} className="premium-input h-9 w-full" /></div>
+                          <div><label className="text-[10px] text-muted-foreground uppercase">Qty</label><input type="number" inputMode="decimal" value={item.qty} min={0.00001} step="0.00001" onChange={(e) => updateItem(i, "qty", Math.max(0, Number(e.target.value)))} className="premium-input h-11 w-full text-center tabular-nums" /></div>
+                          <div><label className="text-[10px] text-muted-foreground uppercase">Unit</label><select value={item.unit} onChange={(e) => updateItem(i, "unit", e.target.value)} className="premium-select h-11 w-full text-[11px]">{itemUnits.map((u) => <option key={u} value={u}>{u}</option>)}</select></div>
+                          <div><label className="text-[10px] text-muted-foreground uppercase">Rate (₹)</label><input type="number" inputMode="decimal" value={item.rate} min={0} step="0.00001" onChange={(e) => updateItem(i, "rate", Math.max(0, Number(e.target.value)))} className="premium-input h-11 w-full tabular-nums" /></div>
                         </div>
+                        {/* The calculator, absorbed: the exact math, live, before saving. */}
+                        {item.qty > 0 && item.rate > 0 && (
+                          <p className="text-[11px] text-muted-foreground tabular-nums">
+                            {item.qty} {item.unit} × ₹{item.rate} = <span className="text-foreground font-medium">{formatCurrency(amount)}</span>
+                            {gstRate > 0 && <> · +{gstRate}% GST = <span className="text-foreground font-semibold">{formatCurrency(amount + tax)}</span></>}
+                          </p>
+                        )}
                         <div className="flex items-center justify-between text-[12px]">
                           <span className="text-muted-foreground">GST: {gstRate}% · Tax: {formatCurrency(tax)}</span>
                           <span className="font-bold text-foreground">{formatCurrency(amount)}</span>
@@ -693,9 +711,9 @@ export default function InvoiceForm({ mode }: InvoiceFormProps) {
                             <td className="text-muted-foreground font-mono text-[12px]">{i + 1}</td>
                             <td><SearchableSelect value={item.productId} onChange={(val) => handleProductChange(i, val)} options={localProducts.map((p) => ({ value: String(p.id), label: p.name, sublabel: p.hsn }))} placeholder="Search Product" /></td>
                             <td><span className="premium-badge bg-success/12 text-success">{gstRate}%</span></td>
-                            <td><input type="number" value={item.qty} min={0.00001} step="0.00001" onChange={(e) => updateItem(i, "qty", Math.max(0, Number(e.target.value)))} className="premium-input h-9 w-full text-center" /></td>
+                            <td><input type="number" inputMode="decimal" value={item.qty} min={0.00001} step="0.00001" onChange={(e) => updateItem(i, "qty", Math.max(0, Number(e.target.value)))} className="premium-input h-9 w-full text-center tabular-nums" /></td>
                             <td><select value={item.unit} onChange={(e) => updateItem(i, "unit", e.target.value)} className="premium-select h-9 w-full text-[12px] !px-2">{itemUnits.map((u) => <option key={u} value={u}>{u}</option>)}</select></td>
-                            <td><input type="number" value={item.rate} min={0} step="0.00001" onChange={(e) => updateItem(i, "rate", Math.max(0, Number(e.target.value)))} className="premium-input h-9 w-full" /></td>
+                            <td><input type="number" inputMode="decimal" value={item.rate} min={0} step="0.00001" onChange={(e) => updateItem(i, "rate", Math.max(0, Number(e.target.value)))} className="premium-input h-9 w-full tabular-nums" /></td>
                             <td className="font-bold text-foreground whitespace-nowrap">{formatCurrency(amount)}</td>
                             <td className="text-muted-foreground whitespace-nowrap text-[12px]">{formatCurrency(tax)}</td>
                             <td><button type="button" onClick={() => removeItem(i)} disabled={items.length === 1} className="p-1.5 rounded-lg text-muted-foreground hover:text-destructive disabled:opacity-30"><Trash2 className="w-4 h-4" /></button></td>
@@ -804,6 +822,83 @@ export default function InvoiceForm({ mode }: InvoiceFormProps) {
           </motion.div>
         )}
       </AnimatePresence>
+
+      {/* ── Review before save: every figure eyeballed once, then committed.
+             Portaled + opaque per the overlay rules; Escape goes back. ── */}
+      {showReview && createPortal(
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Review invoice before saving"
+          className="fixed inset-0 z-[70] flex items-end sm:items-center justify-center bg-black/60 backdrop-blur-sm p-0 sm:p-4"
+          onClick={() => !isSaving && setShowReview(false)}
+          onKeyDown={(e) => { if (e.key === "Escape" && !isSaving) setShowReview(false); }}
+        >
+          <div
+            className="bg-card border border-border/60 w-full sm:max-w-lg max-h-[92vh] overflow-y-auto rounded-t-2xl sm:rounded-2xl shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="px-5 py-4 border-b border-border/40 flex items-center justify-between">
+              <div>
+                <h2 className="text-[15px] font-display font-bold">Review &amp; confirm</h2>
+                <p className="text-[11px] text-muted-foreground">
+                  {form.invoiceNumber} · {selectedCustomer?.name || "Customer"} · {selectedBusiness?.name || ""}
+                </p>
+              </div>
+              <button onClick={() => setShowReview(false)} disabled={isSaving} aria-label="Go back" className="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-secondary/50"><X className="w-4 h-4" /></button>
+            </div>
+
+            <div className="px-5 py-3 space-y-2">
+              {items.map((it, i) => {
+                const product = localProducts.find((p) => p.id === it.productId);
+                const { amount, tax, gstRate } = calcItem(it);
+                return (
+                  <div key={i} className="py-2 border-b border-border/20 last:border-b-0">
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-[13px] font-medium truncate" title={product?.name}>{product?.name || "Item"}</span>
+                      <span className="text-[13px] font-semibold tabular-nums whitespace-nowrap">{formatCurrency(amount + tax)}</span>
+                    </div>
+                    <p className="text-[11px] text-muted-foreground tabular-nums">
+                      {it.qty} {it.unit} × ₹{it.rate} = {formatCurrency(amount)} · +{gstRate}% GST {formatCurrency(tax)}
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
+
+            <div className="px-5 py-3 bg-secondary/20 space-y-1.5 text-[13px] tabular-nums">
+              <div className="flex justify-between"><span className="text-muted-foreground">Taxable value</span><span>{formatCurrency(subtotal)}</span></div>
+              {form.isIGST ? (
+                <div className="flex justify-between"><span className="text-muted-foreground">IGST</span><span>{formatCurrency(totalTax)}</span></div>
+              ) : (
+                <>
+                  <div className="flex justify-between"><span className="text-muted-foreground">CGST</span><span>{formatCurrency(totalTax / 2)}</span></div>
+                  <div className="flex justify-between"><span className="text-muted-foreground">SGST</span><span>{formatCurrency(totalTax / 2)}</span></div>
+                </>
+              )}
+              {form.paymentMode && <div className="flex justify-between"><span className="text-muted-foreground">Payment</span><span className="capitalize">{form.paymentMode}</span></div>}
+              <div className="flex justify-between items-baseline pt-2 border-t border-border/40">
+                <span className="font-semibold">Grand Total</span>
+                <span className="text-xl font-display font-bold text-primary">{formatCurrency(total)}</span>
+              </div>
+            </div>
+
+            <div className="px-5 py-4 flex items-center gap-2">
+              <button onClick={() => setShowReview(false)} disabled={isSaving} className="premium-btn-ghost flex-1 h-11 text-[13px] disabled:opacity-50">
+                Go back
+              </button>
+              <button
+                onClick={() => performSave()}
+                disabled={isSaving}
+                className="premium-btn-primary flex-1 h-11 text-[13px] disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <Save className="w-4 h-4" /> {isSaving ? "Saving…" : "Confirm & Save"}
+              </button>
+            </div>
+          </div>
+        </div>,
+        document.body
+      )}
     </div>
   );
 }

--- a/sweet-rebuild-suite-main/src/pages/InvoiceForm.tsx
+++ b/sweet-rebuild-suite-main/src/pages/InvoiceForm.tsx
@@ -736,7 +736,7 @@ export default function InvoiceForm({ mode }: InvoiceFormProps) {
                   if (item.qty === 0 && item.rate === 0 && !product) return null;
                   return (
                     <div key={item._key} className="space-y-1.5 pb-2 border-b border-border/30">
-                      {product && <div className="text-[12px] font-medium text-foreground truncate">{product.name}</div>}
+                      {product && <div className="text-[12px] font-medium text-foreground truncate" title={product.name}>{product.name}</div>}
                       <div className="flex justify-between"><span className="text-muted-foreground">Qty</span><span className="text-foreground">{item.qty} {item.unit}</span></div>
                       <div className="flex justify-between"><span className="text-muted-foreground">Rate</span><span className="text-foreground">{formatCurrency(item.rate)}/{item.unit}</span></div>
                     </div>

--- a/sweet-rebuild-suite-main/src/pages/InvoiceList.tsx
+++ b/sweet-rebuild-suite-main/src/pages/InvoiceList.tsx
@@ -120,7 +120,7 @@ export default function InvoiceList() {
     return info;
   }, [filtered]);
 
-  const statsInfo = statsData?.totals || { outward: 0, inward: 0, net: 0, tax: 0, count: 0 };
+  const statsInfo = statsData?.totals || { outward: 0, inward: 0, net: 0, tax: 0, count: 0, outward_count: 0, inward_count: 0 };
   const totalOutward = statsInfo.outward;
   const totalInward = statsInfo.inward;
   const totalTaxCollected = statsInfo.tax;
@@ -141,19 +141,16 @@ export default function InvoiceList() {
   // pulls double duty as context AND as an extra figure (count or average).
   // 5 cards: Sales · Purchases · Net Revenue · Tax · Avg Invoice. Avg gives
   // a quick read on whether the period skews toward small or large invoices.
-  const outwardInvCount = useMemo(
-    () => filtered.filter((i) => i.type === "OUTWARD").length,
-    [filtered]
-  );
-  const inwardInvCount = useMemo(
-    () => filtered.filter((i) => i.type === "INWARD").length,
-    [filtered]
-  );
+  // Counts come from the same server aggregate as the money — the loaded
+  // page is only a slice, and "47 outward inv." under a full-year ₹2.23Cr
+  // was exactly the kind of lie that erodes trust in every other number.
+  const outwardInvCount = statsInfo.outward_count ?? 0;
+  const inwardInvCount = statsInfo.inward_count ?? 0;
   const avgInvoice = totalCount > 0 ? (totalOutward + totalInward) / totalCount : 0;
   const stats = [
     { label: "Sales", value: formatCompactCurrency(totalOutward), full: formatCurrency(totalOutward), sub: outwardInvCount > 0 ? `${outwardInvCount} outward inv.` : "—", icon: TrendingUp, color: "text-success" },
     { label: "Purchases", value: formatCompactCurrency(totalInward), full: formatCurrency(totalInward), sub: inwardInvCount > 0 ? `${inwardInvCount} inward inv.` : "—", icon: TrendingDown, color: "text-warning" },
-    { label: "Net Revenue", value: formatCompactCurrency(totalOutward - totalInward), full: formatCurrency(totalOutward - totalInward), sub: "Sales − Purchases", icon: IndianRupee, color: "text-success" },
+    { label: "Net (Sales − Purchases)", value: formatCompactCurrency(totalOutward - totalInward), full: formatCurrency(totalOutward - totalInward), sub: "Money flow, not profit", icon: IndianRupee, color: "text-success" },
     { label: "Tax", value: formatCompactCurrency(totalTaxCollected), full: formatCurrency(totalTaxCollected), sub: "GST collected", icon: Receipt, color: "text-chart-3" },
     { label: "Avg Invoice", value: formatCompactCurrency(avgInvoice), full: formatCurrency(avgInvoice), sub: totalCount > 0 ? `Across ${totalCount} inv.` : "No invoices", icon: Calendar, color: "text-chart-2" },
   ];
@@ -443,10 +440,11 @@ export default function InvoiceList() {
           )}>All Months</button>
         {["Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec","Jan","Feb","Mar"].map((m, i) => {
           const monthNum = String(i < 9 ? i + 4 : i - 8);
-          const hasInvoices = invoices.some((inv) => {
-            const d = new Date(inv.invoice_date);
-            return d.getMonth() + 1 === Number(monthNum);
-          });
+          // Server monthly aggregate, not the loaded page — the first 50 rows
+          // are usually one month, which lit exactly one pill and no others.
+          const hasInvoices = (statsData?.monthly || []).some((r: any) =>
+            Number(r.month) === Number(monthNum) &&
+            ((Number(r.outward_total) || 0) > 0 || (Number(r.inward_total) || 0) > 0));
           return (
             <button key={m} onClick={() => setMonthFilter(monthFilter === monthNum ? "all" : monthNum)}
               className={cn("px-3.5 py-1.5 rounded-full text-[12px] font-semibold transition-all whitespace-nowrap border relative",
@@ -499,8 +497,8 @@ export default function InvoiceList() {
               <th><button onClick={() => { setSortBy("invoiceNumber"); setSortDir(d => sortBy === "invoiceNumber" ? (d === "asc" ? "desc" : "asc") : "asc"); }} className="flex items-center gap-1 hover:text-foreground uppercase tracking-wider">Invoice # {sortBy === "invoiceNumber" && <ArrowUpDown className="w-3 h-3 text-primary" />}</button></th>
               <th><button onClick={() => { setSortBy("date"); setSortDir(d => sortBy === "date" ? (d === "asc" ? "desc" : "asc") : "desc"); }} className="flex items-center gap-1 hover:text-foreground uppercase tracking-wider">Date {sortBy === "date" && <ArrowUpDown className="w-3 h-3 text-primary" />}</button></th>
               <th>Customer</th><th>Business</th>
-              <th><button onClick={() => { setSortBy("total"); setSortDir(d => sortBy === "total" ? (d === "asc" ? "desc" : "asc") : "desc"); }} className="flex items-center gap-1 hover:text-foreground uppercase tracking-wider">Amount {sortBy === "total" && <ArrowUpDown className="w-3 h-3 text-primary" />}</button></th>
-              <th>Tax</th><th title="Effective tax rate inferred from tax÷subtotal — handy for spotting wrong rate slabs at a glance.">Rate</th><th>Type</th><th>Actions</th>
+              <th className="text-right"><button onClick={() => { setSortBy("total"); setSortDir(d => sortBy === "total" ? (d === "asc" ? "desc" : "asc") : "desc"); }} className="flex items-center gap-1 hover:text-foreground uppercase tracking-wider ml-auto">Amount {sortBy === "total" && <ArrowUpDown className="w-3 h-3 text-primary" />}</button></th>
+              <th className="text-right">Tax</th><th className="text-right" title="Effective tax rate inferred from tax÷subtotal — handy for spotting wrong rate slabs at a glance.">Rate</th><th>Type</th><th>Actions</th>
             </tr></thead>
             <tbody>
               {filtered.map((inv, i) => {
@@ -543,12 +541,12 @@ export default function InvoiceList() {
                         <motion.tr initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: Math.min(i * 0.025, 0.5), duration: 0.2 }} className={selected.has(inv.id) ? "!bg-primary/5" : ""}>
                           <td><button onClick={() => toggle(inv.id)} className="text-muted-foreground hover:text-primary">{selected.has(inv.id) ? <CheckSquare className="w-4 h-4 text-primary" /> : <Square className="w-4 h-4" />}</button></td>
                           <td><Link to={`/billing/invoice/${inv.id}`} className="text-primary hover:underline font-semibold">{inv.invoiceNumber}</Link></td>
-                          <td className="text-muted-foreground"><div className="flex items-center gap-1.5"><Calendar className="w-3 h-3" />{formatDate(inv.invoice_date)}</div></td>
+                          <td className="text-muted-foreground whitespace-nowrap">{sortBy === "date" ? <span className="text-muted-foreground/40" title={formatDate(inv.invoice_date)}>·</span> : formatDate(inv.invoice_date)}</td>
                           <td className="text-foreground font-medium">{inv.customerName}</td>
                           <td className="text-muted-foreground text-[12px]">{inv.businessName}</td>
-                          <td className="font-bold text-foreground tabular-nums">{formatCurrency(inv.total)}</td>
-                          <td className="text-muted-foreground text-[12px] tabular-nums">{formatCurrency(inv.totalTax)}</td>
-                          <td className={cn("text-[12px] tabular-nums", rateAnomalous ? "text-warning font-semibold" : "text-muted-foreground")} title={rateAnomalous ? "Not a standard GST slab — open the invoice to verify" : "Tax ÷ subtotal"}>
+                          <td className="font-bold text-foreground tabular-nums text-right whitespace-nowrap">{formatCurrency(inv.total)}</td>
+                          <td className="text-muted-foreground text-[12px] tabular-nums text-right whitespace-nowrap">{formatCurrency(inv.totalTax)}</td>
+                          <td className={cn("text-[12px] tabular-nums text-right", rateAnomalous ? "text-warning font-semibold" : "text-muted-foreground")} title={rateAnomalous ? "Not a standard GST slab — open the invoice to verify" : "Tax ÷ subtotal"}>
                             {ratePct > 0 ? rateLabel : "—"}
                           </td>
                           <td><span className={cn("premium-badge", inv.type === "OUTWARD" ? "bg-success/12 text-success" : "bg-warning/12 text-warning")}>{inv.type}</span>{inv.paymentMode && <div className="text-[10px] text-muted-foreground capitalize mt-0.5">{inv.paymentMode}</div>}</td>
@@ -556,9 +554,17 @@ export default function InvoiceList() {
                         <div className="flex items-center gap-0.5">
                           <Link to={`/billing/invoice/${inv.id}`} aria-label="View invoice" className="p-2 rounded-lg hover:bg-secondary/50 text-muted-foreground hover:text-foreground transition-colors"><Eye className="w-4 h-4" /></Link>
                           <Link to={`/billing/invoice/edit/${inv.id}`} aria-label="Edit invoice" className="p-2 rounded-lg hover:bg-secondary/50 text-muted-foreground hover:text-primary transition-colors"><Pencil className="w-4 h-4" /></Link>
-                          <Link to={`/billing/invoice/${inv.id}/print`} aria-label="Print invoice" className="p-2 rounded-lg hover:bg-secondary/50 text-muted-foreground hover:text-success transition-colors"><Printer className="w-4 h-4" /></Link>
-                          <button onClick={() => navigate("/billing/invoice/add", { state: { duplicateFrom: inv } })} aria-label="Duplicate invoice" className="p-2 rounded-lg hover:bg-secondary/50 text-muted-foreground hover:text-foreground transition-colors"><Copy className="w-4 h-4" /></button>
-                          <button onClick={() => setDeleteTarget({ id: inv.id, name: inv.invoiceNumber })} aria-label="Delete invoice" className="p-2 rounded-lg hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors"><Trash2 className="w-4 h-4" /></button>
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <button aria-label="More actions" className="p-2 rounded-lg hover:bg-secondary/50 text-muted-foreground hover:text-foreground transition-colors"><MoreHorizontal className="w-4 h-4" /></button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end" className="w-44">
+                              <DropdownMenuItem onClick={() => navigate(`/billing/invoice/${inv.id}/print`)}><Printer className="w-4 h-4 mr-2" /> Print</DropdownMenuItem>
+                              <DropdownMenuItem onClick={() => navigate(`/billing/invoice/${inv.id}/print?share=1`)}><Share2 className="w-4 h-4 mr-2" /> Share PDF</DropdownMenuItem>
+                              <DropdownMenuItem onClick={() => navigate("/billing/invoice/add", { state: { duplicateFrom: inv } })}><Copy className="w-4 h-4 mr-2" /> Duplicate</DropdownMenuItem>
+                              <DropdownMenuItem onClick={() => setDeleteTarget({ id: inv.id, name: inv.invoiceNumber })} className="text-destructive focus:text-destructive"><Trash2 className="w-4 h-4 mr-2" /> Delete</DropdownMenuItem>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
                         </div>
                       </td>
                     </motion.tr>

--- a/sweet-rebuild-suite-main/src/pages/InvoicePrint.tsx
+++ b/sweet-rebuild-suite-main/src/pages/InvoicePrint.tsx
@@ -1,11 +1,11 @@
-import { useParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router-dom";
 import { formatCurrency, amountToWords, formatDate } from "@/utils/mockData";
 import { useInvoices, useBusinesses, useCustomers, useInvoice } from "@/hooks/useDataStore";
 import { Printer, Download, Share2, ArrowLeft, MessageCircle, Loader2 } from "lucide-react";
 import { Link } from "react-router-dom";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/utils/utils";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { downloadInvoicePDF, sharePDFViaWebShare, sharePDFViaWhatsApp } from "@/utils/generatePDF";
 import { useToast } from "@/hooks/use-toast";
 
@@ -15,7 +15,32 @@ export default function InvoicePrint() {
   const printRef = useRef<HTMLDivElement>(null);
   const { toast } = useToast();
   const [generating, setGenerating] = useState(false);
+  const [searchParams, setSearchParams] = useSearchParams();
   const { item: inv, isLoading: isLoadingInvoice } = useInvoice(id);
+
+  // ?share=1 — arriving straight from "Confirm & Save" on the phone: once the
+  // printable bill is on screen, open the native share sheet by itself so
+  // save → WhatsApp is one motion. The param is consumed immediately so a
+  // reload or back-swipe never re-triggers it.
+  const autoShared = useRef(false);
+  const wantAutoShare = searchParams.get("share") === "1";
+  useEffect(() => {
+    if (!wantAutoShare || autoShared.current || !inv || !printRef.current) return;
+    autoShared.current = true;
+    setSearchParams({}, { replace: true });
+    // Give the print layout one frame to settle before rasterizing it.
+    const t = setTimeout(async () => {
+      setGenerating(true);
+      try {
+        await sharePDFViaWebShare(printRef.current!, inv);
+      } catch {
+        toast({ title: "Share failed", description: "Use the Share button below.", variant: "destructive" });
+      }
+      setGenerating(false);
+    }, 450);
+    return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [wantAutoShare, inv]);
   const { items: businesses, isLoading: isLoadingBusinesses } = useBusinesses();
   const { items: customers, isLoading: isLoadingCustomers } = useCustomers();
 

--- a/sweet-rebuild-suite-main/src/pages/InwardBills.tsx
+++ b/sweet-rebuild-suite-main/src/pages/InwardBills.tsx
@@ -141,7 +141,7 @@ export default function InwardBills() {
                 >
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0">
-                      <p className="font-medium truncate">{b.supplier?.name || "—"}</p>
+                      <p className="font-medium truncate" title={b.supplier?.name || undefined}>{b.supplier?.name || "—"}</p>
                       <p className="text-xs text-muted-foreground truncate">
                         #{b.invoice_number} · {formatDate(b.invoice_date)}
                       </p>
@@ -154,7 +154,7 @@ export default function InwardBills() {
                     </div>
                   </div>
                   <div className="flex items-center justify-between gap-2 text-[11px] text-muted-foreground">
-                    <span className="truncate">{b.business_name}</span>
+                    <span className="truncate" title={b.business_name}>{b.business_name}</span>
                     <span className="flex items-center gap-2 shrink-0">
                       <span className="tabular-nums">taxable {formatCurrency(Number(b.taxable))}</span>
                       {b.has_file && <Paperclip className="h-3.5 w-3.5" />}
@@ -214,7 +214,7 @@ export default function InwardBills() {
                   >
                     <TableCell className="font-medium">{b.invoice_number}</TableCell>
                     <TableCell>
-                      <div className="max-w-[220px] truncate">{b.supplier?.name || "—"}</div>
+                      <div className="max-w-[220px] truncate" title={b.supplier?.name || undefined}>{b.supplier?.name || "—"}</div>
                       <div className="text-xs text-muted-foreground">{b.supplier?.gst_number || ""}</div>
                     </TableCell>
                     <TableCell className="text-sm">{b.business_name}</TableCell>

--- a/sweet-rebuild-suite-main/src/pages/Reports.tsx
+++ b/sweet-rebuild-suite-main/src/pages/Reports.tsx
@@ -468,7 +468,7 @@ export default function Reports() {
                     </div>
                     <div className="flex-1 min-w-0">
                       <p className={cn("text-[12px] font-display font-semibold truncate", l.color)}>{l.label}</p>
-                      <p className="text-[10px] text-muted-foreground truncate">{l.desc}</p>
+                      <p className="text-[10px] text-muted-foreground truncate" title={l.desc}>{l.desc}</p>
                     </div>
                     <ExternalLink className="w-3 h-3 text-muted-foreground/60 shrink-0" />
                   </div>

--- a/sweet-rebuild-suite-main/src/types/api.ts
+++ b/sweet-rebuild-suite-main/src/types/api.ts
@@ -108,6 +108,8 @@ export interface DashboardStatsResponse {
     tax: number;
     inward_tax: number;
     count: number;
+    outward_count?: number;
+    inward_count?: number;
   };
   monthly: Array<{
     month: number;

--- a/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.ts
+++ b/sweet-rebuild-suite-main/src/utils/parseInvoiceExcel.ts
@@ -338,6 +338,7 @@ export interface ImportReadyInvoice {
   invoice_date: string;
   customerName: string;
   customerGST: string;
+  paymentMode?: string; // "bank" | "cash" | "credit" | "mixed" | "" — from the optional Payment column
   type: "OUTWARD" | "INWARD";
   firmName: string;
   firmGSTIN: string;


### PR DESCRIPTION
> **Stacked on #134** (contains its commits — merge #134 first and this diff shrinks to just Wave A, or merge this one and both land).

## Phone-first billing (works everywhere, built for the counter)
- **Live math while you type**: every mobile line shows `qty × rate = taxable · +GST% = total` — the calculator absorbed into the form. Decimal keyboards + taller touch targets on qty/rate on both layouts.
- **Review & confirm before save**: a portaled sheet (bottom sheet on phone, dialog on desktop) with each line's full math, the tax split, payment mode, and a big Grand Total. The save only runs from its Confirm button.
- **One-motion share**: saving on the phone lands on the printable bill with the **native share sheet opening by itself** (`?share=1`, consumed so reloads never re-share). "Share PDF" also added to invoice detail and the list's new ⋯ menu.

## Invoice list, reconciled and readable
- Stat-card counts and month-pill dots now come from the **same server aggregate as the money** — previously the loaded 50-row slice captioned full-year figures ("47 outward inv." under ₹2.23Cr) and lit exactly one month dot.
- Amount/Tax/Rate right-aligned tabular; per-row dates hidden under their day-group headers; the five always-on row actions collapsed to view/edit + ⋯ (Print / Share PDF / Duplicate / Delete — delete no longer one misclick away); "Net Revenue" renamed to "Net (Sales − Purchases)".
- Backend: `stats` endpoint gains `outward_count`/`inward_count` (+ regression test asserting they sum to the total).

## Verification
Full browser round-trip on desktop **and** 375px: form → review sheet → Confirm → invoice saved with payment mode intact (then cleaned up); auto-share param flow; 39-route UI audit clean; strict `tsc -p tsconfig.app.json`, 56 FE tests, production build, 216 backend tests — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
